### PR TITLE
feat(snell-rollcall): consumer — the outbound connector, both generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,12 +172,7 @@ jobs:
           check internal/snell-rollcall/codec/dtp 100
           check internal/snell-rollcall/codec/router 100
           check internal/snell-rollcall/session 100
-          # The consumer is the one package below the 100% standard. What
-          # remains is error propagation whose reachability depends on a
-          # disconnection landing inside a specific window; it rises as those
-          # branches are either exercised or shown to be duplicated guards and
-          # removed. The floor stops it slipping meanwhile.
-          check internal/snell-rollcall/consumer 96
+          check internal/snell-rollcall/consumer 100
           check internal/transport/ws 100
           check internal/transport/http 100
           check internal/auth 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,12 @@ jobs:
           check internal/snell-rollcall/codec/dtp 100
           check internal/snell-rollcall/codec/router 100
           check internal/snell-rollcall/session 100
+          # The consumer is the one package below the 100% standard. What
+          # remains is error propagation whose reachability depends on a
+          # disconnection landing inside a specific window; it rises as those
+          # branches are either exercised or shown to be duplicated guards and
+          # removed. The floor stops it slipping meanwhile.
+          check internal/snell-rollcall/consumer 96
           check internal/transport/ws 100
           check internal/transport/http 100
           check internal/auth 100

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -46,6 +46,7 @@ import (
 	_ "dhs/internal/osc/consumer"
 	_ "dhs/internal/probel-sw02p/consumer"
 	_ "dhs/internal/probel-sw08p/consumer"
+	_ "dhs/internal/snell-rollcall/consumer"
 	_ "dhs/internal/tsl/consumer"
 
 	// Provider plugins — blank imports register with internal/provider.

--- a/cmd/dhs/testdata/golden/cli-surface.txt
+++ b/cmd/dhs/testdata/golden/cli-surface.txt
@@ -76,6 +76,7 @@ osc-v10  port=8000  Open Sound Control 1.0 — UDP + TCP/length-prefix; core typ
 osc-v11  port=8000  Open Sound Control 1.1 — UDP + TCP/SLIP; adds T/F/N/I + arrays
 probel-sw02p port=2002  Probel SW-P-02 matrix controller (TCP)
 probel-sw08p port=2008  Probel SW-P-08 / SW-P-88 matrix controller (TCP)
+rollcall port=2050  Snell RollCall over IPShare, 16-bit and 32-bit generations
 tsl-v31  port=4000  TSL UMD v3.1 — 18-byte UDP frame (binary tallies, no colour)
 tsl-v40  port=4000  TSL UMD v4.0 — v3.1 extended with XDATA + CHKSUM (2-bit colour per LH/Text/RH per display)
 tsl-v50  port=8901  TSL UMD v5.0 — UDP (≤2048 B) or TCP with DLE/STX wrapper; multi-DMSG; UTF-16LE

--- a/internal/snell-rollcall/codec/payload_file.go
+++ b/internal/snell-rollcall/codec/payload_file.go
@@ -104,13 +104,6 @@ func FileErrorName(v int16) string {
 	}
 }
 
-// Seek origins for the Extra field of a read or write.
-const (
-	SeekStart   int16 = 0
-	SeekCurrent int16 = 1
-	SeekEnd     int16 = 2
-)
-
 // File is FILE_STR, the structure every file operation carries.
 //
 // The two handles are what make the service work across a network where both
@@ -118,13 +111,24 @@ const (
 // echoed back untouched so a reply can be matched, and FileHandle is the
 // server's, valid only on that server.
 //
-// Offset and Extra are overloaded by operation, which is the awkward part of
-// this structure and the reason the helpers below exist:
+// Offset and Extra are overloaded by operation, and they do not merely differ
+// between operations: they change meaning between a request and its own reply.
+// The vendor server says so in as many words (FileServer.c, HandleSpFILEREAD:
+// "NOTE that meaning of rOffset and rExtra differs between SP_FILEREAD and
+// SP_RETFILEREAD"), and getting it wrong reads a file as a stream of empty
+// blocks rather than failing.
 //
-//	Open    Offset holds the open flags, Extra is unused
-//	Read    Offset is where to read from, Extra is the seek origin
-//	Write   Offset is where to write to, Extra is the seek origin
-//	replies Offset is the length or position reached, Extra is the error
+//	message         Offset                  Extra
+//	FileOpen        unused                  the open flags
+//	RetFileOpen     the peer's block size   the error
+//	FileRead        where to read from      how many bytes to read
+//	RetFileRead     how many were read      the error
+//	FileWrite       where to write to       how many bytes to write
+//	FileRet         how many were written   the error
+//
+// The block size a peer returns from an open is its own maximum, and it caps
+// what a read may ask for: the server clamps a larger request rather than
+// refusing it, so a client that ignores the figure simply wastes the excess.
 type File struct {
 	SrcHandle  int16
 	FileHandle int16
@@ -170,7 +174,11 @@ func DecodeFile(b []byte) (File, error) {
 }
 
 // AppendFileOpen builds the payload of a file open: the structure with the
-// flags in Offset, then the path as a NUL-terminated string.
+// flags in Extra, then the path as a NUL-terminated string.
+//
+// The flags go in Extra, not Offset. The vendor server reads them from there
+// (FileServer.c, HandleSpFILEOPEN: "OpenModeFlags = FileSpecIn->rExtra") and
+// overwrites both fields in its reply with the block size and the error.
 //
 // Set OpenBinary for anything that is not line-oriented text. Without it the
 // peer translates line endings, which corrupts a names file or a template
@@ -180,9 +188,54 @@ func AppendFileOpen(dst []byte, srcHandle int16, flags uint16, path string) ([]b
 		return nil, fmt.Errorf("%w: path %d bytes, limit %d",
 			ErrStringTooLong, len(path), MaxFileName-1)
 	}
-	dst = File{SrcHandle: srcHandle, Offset: int32(flags)}.AppendTo(dst)
+	dst = File{SrcHandle: srcHandle, Extra: int16(flags)}.AppendTo(dst)
 	dst = append(dst, path...)
 	return append(dst, 0), nil
+}
+
+// OpenFlags reads the open flags from a file-open request.
+//
+// They are a 16-bit set carried in a signed field, so the binary flag arrives
+// as a negative number. Reading it as signed would make the most important
+// flag in the service look like a malformed request.
+func (f File) OpenFlags() uint16 { return uint16(f.Extra) }
+
+// BlockSize reads the maximum read size from an open reply. Zero means the
+// peer did not say, and a caller should use its own default.
+func (f File) BlockSize() int {
+	if f.Offset <= 0 {
+		return 0
+	}
+	return int(f.Offset)
+}
+
+// FileReadRequest builds a read: where to start, and how many bytes.
+func FileReadRequest(srcHandle, fileHandle int16, offset int32, count int) File {
+	if count > MaxPayload {
+		count = MaxPayload
+	}
+	return File{
+		SrcHandle:  srcHandle,
+		FileHandle: fileHandle,
+		Offset:     offset,
+		Extra:      int16(count),
+	}
+}
+
+// AppendFileWrite builds a write: where to put the data, how much there is,
+// and then the data.
+func AppendFileWrite(dst []byte, srcHandle, fileHandle int16, offset int32, data []byte) ([]byte, error) {
+	if len(data) > MaxPayload-FileSize {
+		return nil, fmt.Errorf("%w: %d bytes of file data in one write",
+			ErrPayloadTooLong, len(data))
+	}
+	dst = File{
+		SrcHandle:  srcHandle,
+		FileHandle: fileHandle,
+		Offset:     offset,
+		Extra:      int16(len(data)),
+	}.AppendTo(dst)
+	return append(dst, data...), nil
 }
 
 // DecodeFileOpen reads a file open request: the structure and the path.

--- a/internal/snell-rollcall/codec/payload_file_test.go
+++ b/internal/snell-rollcall/codec/payload_file_test.go
@@ -37,9 +37,11 @@ func TestFile_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestFile_Err covers the error the Extra field carries on a reply. Only the
-// documented errno values are failures; zero is success and a negative value
-// is a seek origin echoed back, not an error.
+// TestFile_Err covers the error the Extra field carries on a reply.
+//
+// Only a positive value is an error. Zero is success, and a negative one is
+// the field being used for something else: on a request it carries a byte
+// count or the open flags, and the binary flag sets the sign bit.
 func TestFile_Err(t *testing.T) {
 	if err := (File{}).Err(); err != nil {
 		t.Errorf("a zero extra is success, got %v", err)
@@ -88,7 +90,9 @@ func TestFileOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AppendFileOpen: %v", err)
 	}
-	want := mustHex(t, "0007 0000 00008000 0000"+"54454d504c4154452e5a495000")
+	// The flags sit in the last field, not the offset: the vendor server
+	// reads them from there.
+	want := mustHex(t, "0007 0000 00000000 8000"+"54454d504c4154452e5a495000")
 	if !bytes.Equal(got, want) {
 		t.Errorf("encoded\n got %x\nwant %x", got, want)
 	}
@@ -103,10 +107,8 @@ func TestFileOpen(t *testing.T) {
 	if f.SrcHandle != 7 {
 		t.Errorf("source handle = %d, want 7", f.SrcHandle)
 	}
-	// The flags travel in the offset field, which is the awkward part of this
-	// structure and the reason there is a helper.
-	if uint16(f.Offset) != OpenReadOnly|OpenBinary {
-		t.Errorf("flags = %04X, want %04X", uint16(f.Offset), OpenReadOnly|OpenBinary)
+	if f.OpenFlags() != OpenReadOnly|OpenBinary {
+		t.Errorf("flags = %04X, want %04X", f.OpenFlags(), OpenReadOnly|OpenBinary)
 	}
 
 	if _, _, err := DecodeFileOpen(make([]byte, 4)); !errors.Is(err, ErrShortBuffer) {
@@ -341,9 +343,127 @@ func TestDirEntry_String(t *testing.T) {
 	}
 }
 
-// TestSeekOrigins pins the values the Extra field carries on a read or write.
-func TestSeekOrigins(t *testing.T) {
-	if SeekStart != 0 || SeekCurrent != 1 || SeekEnd != 2 {
-		t.Errorf("seek origins are %d/%d/%d, want 0/1/2", SeekStart, SeekCurrent, SeekEnd)
+// TestFile_FieldsChangeMeaningBetweenRequestAndReply is the correction the
+// vendor server forced.
+//
+// Offset and Extra do not merely differ between operations. They change
+// meaning between a request and its own reply, which FileServer.c states
+// outright: "NOTE that meaning of rOffset and rExtra differs between
+// SP_FILEREAD and SP_RETFILEREAD". A client that reads them the same way in
+// both directions asks for zero bytes every time and sees an empty file
+// rather than an error.
+func TestFile_FieldsChangeMeaningBetweenRequestAndReply(t *testing.T) {
+	// A read asks from an offset for a count.
+	req := FileReadRequest(1, 9, 4096, 400)
+	if req.Offset != 4096 {
+		t.Errorf("read offset = %d, want where to read from", req.Offset)
+	}
+	if req.Extra != 400 {
+		t.Errorf("read extra = %d, want how many bytes to read", req.Extra)
+	}
+
+	// The same two fields in the reply are the count read and the error.
+	reply := File{SrcHandle: 1, FileHandle: 9, Offset: 400, Extra: 0}
+	if reply.Err() != nil {
+		t.Errorf("a zero extra on a reply is success, got %v", reply.Err())
+	}
+	if reply.Offset != 400 {
+		t.Errorf("reply offset = %d, want how many bytes were read", reply.Offset)
+	}
+
+	// A read is never asked for more than a frame can carry, whatever the
+	// caller passes.
+	big := FileReadRequest(1, 9, 0, 100000)
+	if int(big.Extra) > MaxPayload {
+		t.Errorf("read asked for %d bytes, more than a frame holds", big.Extra)
+	}
+}
+
+// TestFileOpen_FlagsTravelInExtra pins the field the vendor server actually
+// reads them from: "OpenModeFlags = FileSpecIn->rExtra". Putting them in the
+// offset instead opens every file read-only in text mode, which succeeds and
+// returns corrupted bytes.
+func TestFileOpen_FlagsTravelInExtra(t *testing.T) {
+	got, err := AppendFileOpen(nil, 7, OpenReadOnly|OpenBinary, "A.TXT")
+	if err != nil {
+		t.Fatalf("AppendFileOpen: %v", err)
+	}
+
+	f, path, err := DecodeFileOpen(got)
+	if err != nil {
+		t.Fatalf("DecodeFileOpen: %v", err)
+	}
+	if path != "A.TXT" {
+		t.Errorf("path = %q", path)
+	}
+	if f.Offset != 0 {
+		t.Errorf("offset = %d, want it unused on an open", f.Offset)
+	}
+	if f.OpenFlags() != OpenReadOnly|OpenBinary {
+		t.Errorf("flags = %04X, want %04X", f.OpenFlags(), OpenReadOnly|OpenBinary)
+	}
+
+	// The binary flag is bit 15, so it arrives as a negative number in the
+	// signed field. Reading it as signed would make the most important flag
+	// in the service look like a malformed request.
+	if f.Extra >= 0 {
+		t.Errorf("extra = %d; the binary flag should have set the sign bit", f.Extra)
+	}
+	if f.OpenFlags()&OpenBinary == 0 {
+		t.Error("the binary flag was lost in the signed field")
+	}
+}
+
+// TestFileOpen_ReplyCarriesTheBlockSize pins what an open reply says. Both
+// numeric fields are overwritten: the offset becomes the peer's maximum read
+// size and the extra becomes the error.
+func TestFileOpen_ReplyCarriesTheBlockSize(t *testing.T) {
+	reply := File{SrcHandle: 7, FileHandle: 3, Offset: 410}
+	if reply.BlockSize() != 410 {
+		t.Errorf("block size = %d, want 410", reply.BlockSize())
+	}
+	if reply.Err() != nil {
+		t.Errorf("err = %v, want success", reply.Err())
+	}
+
+	// A peer that says nothing leaves the caller to choose.
+	if got := (File{}).BlockSize(); got != 0 {
+		t.Errorf("block size = %d, want 0 when the peer did not say", got)
+	}
+	if got := (File{Offset: -1}).BlockSize(); got != 0 {
+		t.Errorf("block size = %d, want 0 for a negative figure", got)
+	}
+
+	failed := File{Extra: FileErrNoEntry}
+	if failed.Err() == nil {
+		t.Error("an open that failed must report it")
+	}
+}
+
+func TestFileWrite(t *testing.T) {
+	data := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+
+	got, err := AppendFileWrite(nil, 1, 9, 1024, data)
+	if err != nil {
+		t.Fatalf("AppendFileWrite: %v", err)
+	}
+
+	f, err := DecodeFile(got)
+	if err != nil {
+		t.Fatalf("DecodeFile: %v", err)
+	}
+	if f.Offset != 1024 {
+		t.Errorf("offset = %d, want where to write", f.Offset)
+	}
+	if int(f.Extra) != len(data) {
+		t.Errorf("extra = %d, want the byte count %d", f.Extra, len(data))
+	}
+	if !bytes.Equal(got[FileSize:], data) {
+		t.Errorf("data = %x, want %x", got[FileSize:], data)
+	}
+
+	// More data than a frame can carry is refused rather than truncated.
+	if _, err := AppendFileWrite(nil, 1, 9, 0, make([]byte, MaxPayload)); !errors.Is(err, ErrPayloadTooLong) {
+		t.Errorf("err = %v, want ErrPayloadTooLong", err)
 	}
 }

--- a/internal/snell-rollcall/consumer/compliance_events.go
+++ b/internal/snell-rollcall/consumer/compliance_events.go
@@ -1,0 +1,127 @@
+package rollcall
+
+import (
+	"sync"
+	"time"
+)
+
+// Compliance events name the ways a peer can depart from the specification
+// while still being usable.
+//
+// The posture is the repository's: absorb the deviation and keep running, but
+// never work around one silently. A caller sees the count and the summary, and
+// an operator chasing a fault has something specific to take to a vendor.
+const (
+	// EventLongStringsRefused means a peer advertised the long-string
+	// service and then refused a call that asked for it. The two statements
+	// cannot both be true. We fall back a generation, which works, and say
+	// so, because the fallback is otherwise invisible and changes which
+	// commands are reachable.
+	EventLongStringsRefused = "rollcall_long_strings_refused"
+
+	// EventMenuSpanOverruns means a container line claimed a subtree longer
+	// than the menu that contains it. The span is clamped to what is there,
+	// so the tree is still built, but the line count and the claim disagree.
+	EventMenuSpanOverruns = "rollcall_menu_span_overruns"
+
+	// EventMenuCountMismatch means a device delivered a different number of
+	// menu lines than it announced. The lines that arrived are kept.
+	EventMenuCountMismatch = "rollcall_menu_count_mismatch"
+
+	// EventDuplicateCommand means two menu lines on one port claimed the
+	// same command number. Both are kept, and the first keeps the label,
+	// because a value written to either would reach the same place.
+	EventDuplicateCommand = "rollcall_duplicate_command"
+
+	// EventAccessGated means a menu line was replaced by the placeholder a
+	// server substitutes for a line above the session's user level. It is
+	// not a fault: it is how the protocol hides a line. It is reported so
+	// that "the menu is shorter than the manual says" has an answer.
+	EventAccessGated = "rollcall_access_gated"
+
+	// EventValueModeEmpty means a value reply set neither the value, the
+	// string nor the data flag, so it carries nothing. The read returns an
+	// empty value of the object's kind rather than failing.
+	EventValueModeEmpty = "rollcall_value_mode_empty"
+
+	// EventUnsolicitedSession means a push arrived on a session index we
+	// hold, naming a command the walked menu does not contain. It is
+	// delivered, because the device knows its own commands better than a
+	// cached walk does.
+	EventUnsolicitedCommand = "rollcall_unsolicited_command"
+
+	// EventDisplayLineOutOfRange means a status line arrived for a line
+	// number outside the four the display service defines and outside the
+	// two negative priorities. It is kept under its own number.
+	EventDisplayLineOutOfRange = "rollcall_display_line_out_of_range"
+)
+
+// ComplianceEvent is one recorded deviation.
+type ComplianceEvent struct {
+	Name   string
+	Detail string
+	At     time.Time
+	Count  int
+}
+
+// compliance collects deviations without unbounded growth: one entry per kind,
+// with a count and the most recent detail. A device that misbehaves on every
+// one of sixty-five thousand destinations must not fill memory with the
+// evidence.
+type compliance struct {
+	mu     sync.Mutex
+	events map[string]*ComplianceEvent
+	order  []string
+}
+
+func (c *compliance) fire(name, detail string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.events == nil {
+		c.events = make(map[string]*ComplianceEvent)
+	}
+	e, ok := c.events[name]
+	if !ok {
+		e = &ComplianceEvent{Name: name}
+		c.events[name] = e
+		c.order = append(c.order, name)
+	}
+	e.Detail = detail
+	e.At = now
+	e.Count++
+}
+
+// snapshot returns the events in the order they were first seen.
+func (c *compliance) snapshot() []ComplianceEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	out := make([]ComplianceEvent, 0, len(c.order))
+	for _, name := range c.order {
+		out = append(out, *c.events[name])
+	}
+	return out
+}
+
+// fire records a deviation and logs it once per kind at warning level.
+//
+// Repeats are counted rather than logged, because a device that deviates on
+// every line of a large menu would otherwise bury everything else in the log.
+func (p *Plugin) fire(name, detail string) {
+	first := false
+	p.comp.mu.Lock()
+	if p.comp.events == nil || p.comp.events[name] == nil {
+		first = true
+	}
+	p.comp.mu.Unlock()
+
+	p.comp.fire(name, detail, p.clk.Now())
+	if first {
+		p.log.Warn("rollcall: compliance", "event", name, "detail", detail)
+	}
+}
+
+// ComplianceEvents returns the deviations seen so far, most-recently-updated
+// detail per kind, in the order the kinds were first seen.
+func (p *Plugin) ComplianceEvents() []ComplianceEvent { return p.comp.snapshot() }

--- a/internal/snell-rollcall/consumer/concurrency_test.go
+++ b/internal/snell-rollcall/consumer/concurrency_test.go
@@ -1,0 +1,349 @@
+package rollcall
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/consumer"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestConcurrentSessionOpenKeepsOne covers two callers reaching for the same
+// port at once.
+//
+// A session costs a round trip, so the check for an existing one happens
+// before the call rather than under a lock held across it. That leaves a
+// window where both callers see none and both open one, and the loser has to
+// close its own: a port with two sessions wastes one of the few a unit has,
+// and a unit that runs out stops answering anybody.
+//
+// The device holds both calls until each has arrived, so the race is forced
+// rather than hoped for.
+func TestConcurrentSessionOpenKeepsOne(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, func(d *device) {
+		d.gateCall = gate
+		d.setMenu(1, testMenu())
+	})
+
+	// Two callers reach for port 1 together.
+	var wg sync.WaitGroup
+	results := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := h.plugin.session(context.Background(), 1)
+			results[i] = err
+		}()
+	}
+
+	// Wait until both calls are in flight, then let them through together.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		seen := h.device.callsSeen
+		h.device.mu.Unlock()
+		if seen >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d calls arrived; the race was not set up", seen)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(gate)
+	wg.Wait()
+
+	for i, err := range results {
+		if err != nil {
+			t.Errorf("caller %d: %v", i, err)
+		}
+	}
+
+	// Exactly one session is kept for the port, and both callers got it.
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+
+	l.mu.Lock()
+	kept := len(l.sessions)
+	l.mu.Unlock()
+	if kept != 1 {
+		t.Errorf("the link holds %d sessions for one port, want 1", kept)
+	}
+
+	// And the loser closed its own, so the device is not left holding two.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		open := len(h.device.sessions)
+		h.device.mu.Unlock()
+		if open == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("the device holds %d sessions, want 1", open)
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestConcurrentFileSessionKeepsOne covers the same race on the file service,
+// which opens its own session because services are all-or-nothing.
+func TestConcurrentFileSessionKeepsOne(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, func(d *device) {
+		d.gateCall = gate
+		d.setFile("A.BIN", []byte("x"))
+	})
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = h.plugin.fileSession(context.Background(), 0)
+		}()
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		seen := h.device.callsSeen
+		h.device.mu.Unlock()
+		if seen >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d calls arrived", seen)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(gate)
+	wg.Wait()
+
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+
+	l.mu.Lock()
+	kept := len(l.fileSessions)
+	l.mu.Unlock()
+	if kept != 1 {
+		t.Errorf("the link holds %d file sessions, want 1", kept)
+	}
+}
+
+// TestDisconnectDuringSessionOpen covers a caller disconnecting while a
+// session is being opened. The session must not be left registered on a link
+// that is already gone, and the caller must be told rather than handed one.
+func TestDisconnectDuringSessionOpen(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, func(d *device) { d.gateCall = gate })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.plugin.session(context.Background(), 1)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		seen := h.device.callsSeen
+		h.device.mu.Unlock()
+		if seen >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the call never arrived")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Disconnect while the call is in flight, then let it complete.
+	_ = h.plugin.Disconnect()
+	close(gate)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("a session opened on a link that was closed should not be handed out")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the caller was left waiting")
+	}
+}
+
+// TestDisconnectDuringFileOpen covers the same for the file service.
+func TestDisconnectDuringFileOpen(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, func(d *device) { d.gateCall = gate })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.plugin.fileSession(context.Background(), 0)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		seen := h.device.callsSeen
+		h.device.mu.Unlock()
+		if seen >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the call never arrived")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	_ = h.plugin.Disconnect()
+	close(gate)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("a file session opened on a closed link should not be handed out")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the caller was left waiting")
+	}
+}
+
+// failingNet refuses to dial, which is what an unreachable device looks like.
+type failingNet struct{ err error }
+
+func (f failingNet) Dial(context.Context, string, string) (net.Conn, error) {
+	return nil, f.err
+}
+func (failingNet) Listen(context.Context, string, string) (net.Listener, error) { return nil, nil }
+func (failingNet) ListenPacket(context.Context, string, string) (net.PacketConn, error) {
+	return nil, nil
+}
+
+func TestConnect_DialFails(t *testing.T) {
+	want := errors.New("no route to host")
+	p := New(plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Net:     failingNet{err: want},
+		Clock:   clock.NewFake(time.Time{}),
+		Metrics: metrics.NewConnector(),
+	})
+
+	err := p.Connect(context.Background(), "10.0.0.1", DefaultPort)
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v, want the dialler's own reason", err)
+	}
+	// A failed connection leaves nothing behind.
+	if _, err := p.GetDeviceInfo(context.Background()); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+// TestConnect_HandshakeFails covers a peer that accepts the connection and
+// then refuses the first message, which is what a wrong port looks like.
+func TestConnect_HandshakeFails(t *testing.T) {
+	dialer := &pipeNet{t: t}
+	dialer.fn = func() net.Conn {
+		ours, theirs := net.Pipe()
+		d := newDevice(t, theirs)
+		d.refuse[codec.MsgGetDevInfo] = true
+		return ours
+	}
+
+	p := New(plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Net:     dialer,
+		Clock:   clock.NewFake(time.Time{}),
+		Metrics: metrics.NewConnector(),
+	})
+
+	if err := p.Connect(context.Background(), "10.0.0.1", DefaultPort); err == nil {
+		t.Fatal("a refused handshake should fail the connection")
+	}
+	if _, err := p.GetDeviceInfo(context.Background()); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("err = %v, want ErrNotConnected", err)
+	}
+}
+
+// TestConnect_DefaultPort covers a caller that names no port. The IPShare port
+// is what a gateway listens on, so it is the sensible default rather than an
+// error.
+func TestConnect_DefaultPort(t *testing.T) {
+	dialer := &pipeNet{t: t}
+	dialer.fn = func() net.Conn {
+		ours, theirs := net.Pipe()
+		newDevice(t, theirs)
+		return ours
+	}
+
+	p := New(plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Net:     dialer,
+		Clock:   clock.NewFake(time.Time{}),
+		Metrics: metrics.NewConnector(),
+	})
+	t.Cleanup(func() { _ = p.Disconnect() })
+
+	if err := p.Connect(context.Background(), "10.0.0.1", 0); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if p.port != DefaultPort {
+		t.Errorf("port = %d, want the default %d", p.port, DefaultPort)
+	}
+}
+
+// TestPumpStopsWithTheLink covers the announcement pump ending when the device
+// goes away, rather than spinning on a dead link.
+func TestPumpStopsWithTheLink(t *testing.T) {
+	h := newHarness(t, nil)
+
+	// An announcement arrives and is absorbed by the pump.
+	info, err := codec.DeviceInfo{ID: codec.ID{Name: "Vega"}}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.send(codec.Frame{
+		Dst:     codec.Broadcast(),
+		Src:     gatewayAddr,
+		Type:    codec.MsgIam,
+		Payload: info,
+	})
+
+	// An announcement that will not decode must not stop the pump either.
+	h.device.send(codec.Frame{
+		Dst:     codec.Broadcast(),
+		Src:     gatewayAddr,
+		Type:    codec.MsgIam,
+		Payload: []byte{0x01},
+	})
+
+	h.device.close()
+
+	// The link notices and the plugin refuses further work rather than
+	// hanging.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := h.plugin.GetSlotInfo(context.Background(), 1); err != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the plugin kept working after the device went away")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/snell-rollcall/consumer/connect.go
+++ b/internal/snell-rollcall/consumer/connect.go
@@ -1,0 +1,248 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// link holds one connection and the sessions opened over it.
+//
+// Sessions are per port rather than per device, because a menu walk is bound
+// to the port it was opened on and a gateway's cards each have their own. They
+// are opened on demand and kept, since opening one costs a round trip and
+// closing one is what a unit runs out of.
+type link struct {
+	sess *session.Link
+	keep *session.Keepalive
+
+	// gateway is what the peer said it was during the handshake.
+	gateway codec.DeviceInfo
+
+	mu       sync.Mutex
+	sessions map[uint8]*session.Session // control and menu, by port
+
+	// fileSessions are separate because services are negotiated together and
+	// all-or-nothing: asking for the file service on the control session
+	// would make a unit without one uncontrollable.
+	fileSessions map[uint8]*session.Session
+
+	closed bool
+}
+
+// Connect opens the link and learns who is on the other end.
+//
+// It is callable more than once: a reconnect closes what came before, so a
+// caller that reconnects does not leak the sessions it had.
+func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
+	if port == 0 {
+		port = DefaultPort
+	}
+	addr := net.JoinHostPort(ip, strconv.Itoa(port))
+
+	// Anything from a previous connection goes first, including its sessions,
+	// which are terminated properly rather than abandoned. Disconnect cannot
+	// fail; it reports an error only to satisfy the neutral contract.
+	_ = p.Disconnect()
+
+	conn, err := p.net.Dial(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("rollcall: dial %s: %w", addr, err)
+	}
+
+	sl := session.NewLink(conn, session.Config{}, p.deps)
+
+	// The first message on a new connection. It learns our address, which the
+	// gateway assigns, and the gateway's own, which we cannot know; and its
+	// service mask, which decides which generation we may ask for.
+	info, err := sl.Handshake(ctx)
+	if err != nil {
+		_ = sl.Close()
+		return fmt.Errorf("rollcall: handshake with %s: %w", addr, err)
+	}
+
+	l := &link{
+		sess:         sl,
+		gateway:      info,
+		sessions:     make(map[uint8]*session.Session),
+		fileSessions: make(map[uint8]*session.Session),
+	}
+	l.keep = session.NewKeepalive(context.WithoutCancel(ctx), sl, nil)
+
+	p.mu.Lock()
+	p.link = l
+	p.addr = ip
+	p.port = port
+	p.trees = make(map[int]*slotTree)
+	p.events = make(chan struct{})
+	p.mu.Unlock()
+
+	p.log.Info("rollcall: connected",
+		"addr", addr,
+		"gateway", info.Address.String(),
+		"name", info.ID.Name,
+		"type", codec.UnitTypeName(info.ID.TypeID),
+		"services", info.ID.Services.String(),
+		"generation", generationName(info.ID.Services))
+
+	go p.pumpBackChannel()
+	return nil
+}
+
+// generationName says which wire generation a peer can speak, for a log line.
+func generationName(s codec.Service) string {
+	if s.LongStrings() {
+		return "32-bit"
+	}
+	return "16-bit"
+}
+
+// Disconnect closes the link and every session on it.
+//
+// Sessions are terminated rather than dropped. Servers do not time idle
+// sessions out, so one we abandon is held until the unit reboots, and a unit
+// that runs out of sessions stops answering anybody.
+func (p *Plugin) Disconnect() error {
+	p.mu.Lock()
+	l := p.link
+	p.link = nil
+	events := p.events
+	p.mu.Unlock()
+
+	if l == nil {
+		return nil
+	}
+	select {
+	case <-events:
+	default:
+		close(events)
+	}
+	l.close()
+	return nil
+}
+
+func (l *link) close() {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return
+	}
+	l.closed = true
+	sessions := make([]*session.Session, 0, len(l.sessions)+len(l.fileSessions))
+	for _, s := range l.sessions {
+		sessions = append(sessions, s)
+	}
+	for _, s := range l.fileSessions {
+		sessions = append(sessions, s)
+	}
+	l.sessions = nil
+	l.fileSessions = nil
+	l.mu.Unlock()
+
+	for _, s := range sessions {
+		_ = s.Close()
+	}
+	_ = l.sess.Close()
+}
+
+// conn returns the current link, or the neutral not-connected error.
+func (p *Plugin) conn() (*link, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.link == nil {
+		return nil, consumer.ErrNotConnected
+	}
+	return p.link, nil
+}
+
+// session returns the session for a port, opening one if there is none.
+//
+// The 32-bit generation is asked for whenever the peer advertises it, because
+// it is the only one that can express a router's command space and its menu
+// requests are stateless. A peer that refuses the whole call because of that
+// bit is retried without it: services are all-or-nothing, so a partial grant
+// is not a thing that can happen.
+func (p *Plugin) session(ctx context.Context, port uint8) (*session.Session, error) {
+	l, err := p.conn()
+	if err != nil {
+		return nil, err
+	}
+
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil, consumer.ErrNotConnected
+	}
+	if s, ok := l.sessions[port]; ok {
+		l.mu.Unlock()
+		return s, nil
+	}
+	l.mu.Unlock()
+
+	peer := l.sess.RemoteAddress()
+	peer.Port = port
+
+	wantLong := l.gateway.ID.Services.LongStrings()
+	s, err := p.call(ctx, l, peer, wantLong)
+	if err != nil {
+		return nil, err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		_ = s.Close()
+		return nil, consumer.ErrNotConnected
+	}
+	// Another caller may have opened one while we were waiting for the
+	// reply. Keep theirs and close ours, so a port never has two.
+	if existing, ok := l.sessions[port]; ok {
+		go func() { _ = s.Close() }()
+		return existing, nil
+	}
+	l.sessions[port] = s
+	return s, nil
+}
+
+// call opens one session, falling back a generation if the peer refuses.
+func (p *Plugin) call(ctx context.Context, l *link, peer codec.Address, wantLong bool) (*session.Session, error) {
+	s, err := session.Call(ctx, l.sess, peer, sessionServices(wantLong),
+		codec.LevelSupervisor, p.identity())
+	if err == nil {
+		return s, nil
+	}
+	if !wantLong {
+		return nil, fmt.Errorf("rollcall: call %s: %w", peer, err)
+	}
+
+	// The peer advertised long strings and then refused a call that asked for
+	// them. That is a deviation worth naming, because the two statements
+	// cannot both be true, and the fallback hides it from the caller.
+	p.fire(EventLongStringsRefused, fmt.Sprintf(
+		"%s advertises SV_LONGSTR but refused a call requesting it: %v", peer, err))
+
+	s, err = session.Call(ctx, l.sess, peer, sessionServices(false),
+		codec.LevelSupervisor, p.identity())
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: call %s: %w", peer, err)
+	}
+	return s, nil
+}
+
+// Uses32Bit reports whether the session for a port speaks the 32-bit
+// generation. Callers that need to know which message types will be used ask
+// this rather than inferring it from the device.
+func (p *Plugin) Uses32Bit(ctx context.Context, slot int) (bool, error) {
+	s, err := p.session(ctx, uint8(slot))
+	if err != nil {
+		return false, err
+	}
+	return s.Uses32Bit(), nil
+}

--- a/internal/snell-rollcall/consumer/consumer_test.go
+++ b/internal/snell-rollcall/consumer/consumer_test.go
@@ -1,0 +1,580 @@
+package rollcall
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+func TestFactory(t *testing.T) {
+	f := &Factory{}
+	meta := f.Meta()
+
+	if meta.Name != "rollcall" {
+		t.Errorf("name = %q, want rollcall", meta.Name)
+	}
+	if meta.DefaultPort != 2050 {
+		t.Errorf("default port = %d, want the IPShare port 2050", meta.DefaultPort)
+	}
+	if meta.Description == "" {
+		t.Error("the connector should describe itself")
+	}
+	// Both generations are the point of this connector, so the description
+	// should say so rather than leaving an operator to find out.
+	if !strings.Contains(meta.Description, "16-bit") || !strings.Contains(meta.Description, "32-bit") {
+		t.Errorf("description = %q, want it to name both generations", meta.Description)
+	}
+}
+
+// TestConnect_LearnsTheGateway covers the handshake, which is the first thing
+// on a new connection and the only way a TCP client learns either address.
+func TestConnect_LearnsTheGateway(t *testing.T) {
+	h := newHarness(t, nil)
+
+	info, err := h.plugin.GetDeviceInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetDeviceInfo: %v", err)
+	}
+	if info.IP != "10.6.250.105" || info.Port != DefaultPort {
+		t.Errorf("= %s:%d", info.IP, info.Port)
+	}
+	if info.ProtocolVersion != int(codec.ProtocolVersion) {
+		t.Errorf("protocol version = %d", info.ProtocolVersion)
+	}
+	if info.NumSlots != 2 {
+		t.Errorf("slots = %d, want the device's 2 ports", info.NumSlots)
+	}
+}
+
+// TestConnect_PrefersTheLongStringGeneration pins the negotiation. A peer that
+// advertises long strings gets a call asking for them, because that generation
+// is the only one that can express a router's command space.
+func TestConnect_PrefersTheLongStringGeneration(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	long, err := h.plugin.Uses32Bit(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Uses32Bit: %v", err)
+	}
+	if !long {
+		t.Error("a peer advertising long strings should be asked for them")
+	}
+}
+
+// TestConnect_FallsBackAGeneration covers a peer that advertises long strings
+// and then refuses a call asking for them.
+//
+// Services are all-or-nothing, so there is no partial grant to fall back to:
+// the client must issue a second call without the bit. The two statements the
+// peer made cannot both be true, so the fallback is recorded rather than done
+// silently.
+func TestConnect_FallsBackAGeneration(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.refuseLongStrings = true
+		d.setMenu(1, testMenu())
+	})
+
+	long, err := h.plugin.Uses32Bit(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Uses32Bit: %v", err)
+	}
+	if long {
+		t.Error("the session should have fallen back to the 16-bit generation")
+	}
+
+	// And the connector said so, because a silent fallback changes which
+	// commands are reachable.
+	if !hasEvent(h.plugin, EventLongStringsRefused) {
+		t.Error("the fallback was not recorded as a compliance event")
+	}
+
+	// The fallback session still works.
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk on the fallback session: %v", err)
+	}
+	if len(objects) != len(testMenu()) {
+		t.Errorf("walked %d objects, want %d", len(objects), len(testMenu()))
+	}
+}
+
+// TestWalk_BuildsTheTreeFromSpans is the menu model, and the one thing most
+// likely to be got wrong.
+//
+// The array is flat and a container's step is the span of its whole subtree,
+// not the count of its immediate children. Reading it as a child count nests
+// everything below the second level in the wrong place, and the result still
+// looks like a tree.
+func TestWalk_BuildsTheTreeFromSpans(t *testing.T) {
+	// A tree two levels deep, where the two readings differ:
+	//   Root      span 4   the whole subtree
+	//     Video   span 2   its own two children
+	//       Gain
+	//       Offset
+	//     Mode
+	menu := []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleList, Step: 4, Text: "Root"},
+		{MenuIndex: 1, Style: codec.StyleList, Step: 2, Text: "Video"},
+		{MenuIndex: 2, Style: codec.StyleNumber, Command: 10, Text: "Gain"},
+		{MenuIndex: 3, Style: codec.StyleNumber, Command: 11, Text: "Offset"},
+		{MenuIndex: 4, Style: codec.StyleNumber, Command: 12, Text: "Mode"},
+	}
+	h := newHarness(t, func(d *device) { d.setMenu(1, menu) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objects) != len(menu) {
+		t.Fatalf("walked %d objects, want %d", len(objects), len(menu))
+	}
+
+	want := map[string][]string{
+		"Root":   {"Root"},
+		"Video":  {"Root", "Video"},
+		"Gain":   {"Root", "Video", "Gain"},
+		"Offset": {"Root", "Video", "Offset"},
+		"Mode":   {"Root", "Mode"},
+	}
+	for _, o := range objects {
+		got := want[o.Label]
+		if got == nil {
+			t.Errorf("unexpected object %q", o.Label)
+			continue
+		}
+		if strings.Join(o.Path, ".") != strings.Join(got, ".") {
+			t.Errorf("%q is at %v, want %v", o.Label, o.Path, got)
+		}
+	}
+
+	// "Mode" is the line that separates the two readings. Under a child count
+	// it would land inside Video; under a span it is a sibling of it.
+	for _, o := range objects {
+		if o.Label == "Mode" && len(o.Path) != 2 {
+			t.Errorf("Mode is at %v; the span was read as a child count", o.Path)
+		}
+	}
+}
+
+// TestWalk_MapsStylesToKinds covers the translation that makes a RollCall menu
+// legible to a caller that has never heard of RollCall.
+func TestWalk_MapsStylesToKinds(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	byLabel := map[string]consumer.Object{}
+	for _, o := range objects {
+		byLabel[o.Label] = o
+	}
+
+	tests := []struct {
+		label  string
+		kind   consumer.ValueKind
+		write  bool
+		header bool
+	}{
+		{"Video", consumer.KindUnknown, false, true},  // a container is a node
+		{"Gain", consumer.KindInt, true, false},       // a number
+		{"Enable", consumer.KindBool, true, false},    // a checkbox is a boolean
+		{"Name", consumer.KindString, true, false},    // an editable string
+		{"Status", consumer.KindString, false, false}, // a display is read-only
+	}
+	for _, tc := range tests {
+		o, ok := byLabel[tc.label]
+		if !ok {
+			t.Errorf("%q is missing from the walk", tc.label)
+			continue
+		}
+		if o.Kind != tc.kind {
+			t.Errorf("%q is %s, want %s", tc.label, o.Kind, tc.kind)
+		}
+		if o.HasWrite() != tc.write {
+			t.Errorf("%q writable = %v, want %v", tc.label, o.HasWrite(), tc.write)
+		}
+		if !o.HasRead() {
+			t.Errorf("%q should be readable", tc.label)
+		}
+		if o.SubGroupMarker != tc.header {
+			t.Errorf("%q header = %v, want %v", tc.label, o.SubGroupMarker, tc.header)
+		}
+	}
+
+	// A number carries its range, and its format string is the closest thing
+	// a menu line has to a unit.
+	gain := byLabel["Gain"]
+	if gain.Min != int64(-60) || gain.Max != int64(6) {
+		t.Errorf("Gain range = %v..%v, want -60..6", gain.Min, gain.Max)
+	}
+	if gain.Unit != "dB" {
+		t.Errorf("Gain unit = %q, want dB from the format string", gain.Unit)
+	}
+	if gain.ID != 0x0113 {
+		t.Errorf("Gain id = %d, want its command number", gain.ID)
+	}
+}
+
+// TestWalk_DisabledLineIsReadOnly covers the flag that decides whether a
+// caller may write. A greyed line in the vendor's own panel is one a device
+// will refuse, so reporting it as writable would invite a failure.
+func TestWalk_DisabledLineIsReadOnly(t *testing.T) {
+	menu := []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleNumber, Command: 1, Text: "Open"},
+		{MenuIndex: 1, Style: codec.StyleNumber | codec.StyleDisabled, Command: 2, Text: "Locked"},
+	}
+	h := newHarness(t, func(d *device) { d.setMenu(1, menu) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	for _, o := range objects {
+		switch o.Label {
+		case "Open":
+			if !o.HasWrite() {
+				t.Error("an enabled number should be writable")
+			}
+		case "Locked":
+			if o.HasWrite() {
+				t.Error("a disabled line must not be reported as writable")
+			}
+			if !o.HasRead() {
+				t.Error("a disabled line is still readable")
+			}
+		}
+	}
+}
+
+// TestWalk_ReportsAccessGating covers the placeholder a server substitutes for
+// a line above the session's user level.
+//
+// It is not a removal: line counts are identical at every level, so a client
+// comparing counts sees no difference. Only the flags reveal it, which is why
+// it is detected and reported.
+func TestWalk_ReportsAccessGating(t *testing.T) {
+	menu := []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleNumber, Command: 1, Text: "Visible"},
+		{MenuIndex: 1, Style: codec.StyleData | codec.StyleHidden | codec.StyleDisabled,
+			Command: 0, Text: "Reserved"},
+	}
+	h := newHarness(t, func(d *device) { d.setMenu(1, menu) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	// The line is still there, which is the whole point: it is substituted,
+	// not removed.
+	if len(objects) != 2 {
+		t.Errorf("walked %d objects, want 2; gating substitutes rather than removes", len(objects))
+	}
+	if !hasEvent(h.plugin, EventAccessGated) {
+		t.Error("the gated line was not reported")
+	}
+}
+
+// TestGetValue_ResolvesColdByLabel covers the promise that a caller may name an
+// object without knowing its command number, and without having walked first.
+func TestGetValue_ResolvesColdByLabel(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: -12})
+	})
+
+	// No walk first. The read has to do it.
+	v, err := h.plugin.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Gain"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if v.Kind != consumer.KindInt || v.Int != -12 {
+		t.Errorf("= %s %d, want int -12", v.Kind, v.Int)
+	}
+}
+
+func TestGetValue_ResolvesByPathAndID(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 3})
+	})
+	ctx := context.Background()
+
+	for _, req := range []consumer.ValueRequest{
+		{Slot: 1, Path: "Video.Gain"},
+		{Slot: 1, Label: "gain"}, // matching is case-insensitive
+		{Slot: 1, ID: 0x0113},
+	} {
+		v, err := h.plugin.GetValue(ctx, req)
+		if err != nil {
+			t.Errorf("%+v: %v", req, err)
+			continue
+		}
+		if v.Int != 3 {
+			t.Errorf("%+v = %d, want 3", req, v.Int)
+		}
+	}
+}
+
+func TestGetValue_Unresolvable(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	for _, req := range []consumer.ValueRequest{
+		{Slot: 1, Label: "no such object"},
+		{Slot: 1, Path: "nowhere.at.all"},
+		{Slot: 1}, // names nothing at all
+	} {
+		if _, err := h.plugin.GetValue(ctx, req); err == nil {
+			t.Errorf("%+v should not have resolved", req)
+		}
+	}
+}
+
+// TestSetValue_ReturnsWhatTheDeviceStored pins the property that makes a write
+// worth reading back. The reply carries the device's own value, so a caller
+// that asked for something out of range learns what it actually got without a
+// second read.
+func TestSetValue_ReturnsWhatTheDeviceStored(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	// In range: stored as asked.
+	got, err := h.plugin.SetValue(ctx,
+		consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		consumer.Value{Kind: consumer.KindInt, Int: -20})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Int != -20 {
+		t.Errorf("= %d, want -20", got.Int)
+	}
+
+	// Above the range: the device clamps, and only the reply says so.
+	got, err = h.plugin.SetValue(ctx,
+		consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		consumer.Value{Kind: consumer.KindInt, Int: 9999})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Int != 6 {
+		t.Errorf("= %d, want the device's ceiling of 6", got.Int)
+	}
+
+	// And a read agrees, so the reply was the truth rather than an echo.
+	back, err := h.plugin.GetValue(ctx, consumer.ValueRequest{Slot: 1, Label: "Gain"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if back.Int != 6 {
+		t.Errorf("read back %d, want 6", back.Int)
+	}
+}
+
+func TestSetValue_Bool(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	got, err := h.plugin.SetValue(ctx,
+		consumer.ValueRequest{Slot: 1, Label: "Enable"},
+		consumer.Value{Kind: consumer.KindBool, Bool: true})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Kind != consumer.KindBool || !got.Bool {
+		t.Errorf("= %s %v, want a true boolean", got.Kind, got.Bool)
+	}
+
+	got, err = h.plugin.SetValue(ctx,
+		consumer.ValueRequest{Slot: 1, Label: "Enable"},
+		consumer.Value{Kind: consumer.KindBool, Bool: false})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Bool {
+		t.Error("= true, want false")
+	}
+}
+
+func TestSetValue_String(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	got, err := h.plugin.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Label: "Name"},
+		consumer.Value{Kind: consumer.KindString, Str: "Camera 1"})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Kind != consumer.KindString || got.Str != "Camera 1" {
+		t.Errorf("= %s %q", got.Kind, got.Str)
+	}
+}
+
+// TestSetDefault covers restoring a device's own default, which is a distinct
+// operation rather than a write of a known value: only the device knows what
+// its default is. The preset flag asks for it, and the numeric field is
+// ignored.
+func TestSetDefault(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.SetValue(ctx,
+		consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		consumer.Value{Kind: consumer.KindInt, Int: 5}); err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+
+	got, err := h.plugin.SetDefault(ctx, consumer.ValueRequest{Slot: 1, Label: "Gain"})
+	if err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+	if got.Int != -60 {
+		t.Errorf("= %d, want the device's default of -60", got.Int)
+	}
+}
+
+// TestGetSlotInfo covers a port's identity, which is the card in it.
+func TestGetSlotInfo(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	info, err := h.plugin.GetSlotInfo(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetSlotInfo: %v", err)
+	}
+	if info.Slot != 1 {
+		t.Errorf("slot = %d", info.Slot)
+	}
+	if info.State != consumer.SlotStatePresent || !info.IsOnline {
+		t.Errorf("= %v online=%v, want a present card", info.State, info.IsOnline)
+	}
+
+	// The type id names the product, which is what makes an inventory
+	// legible without an operator knowing the numbers.
+	if info.Identity["type"] != "5915 Embedded Audio" {
+		t.Errorf("type = %q, want the product name for id 623", info.Identity["type"])
+	}
+	if info.Identity["name"] != "5915 Card" {
+		t.Errorf("name = %q", info.Identity["name"])
+	}
+	// The version and the id together are what identify a device model, so
+	// both are reported rather than only the name.
+	if info.Identity["version"] != "2.1a.cs3" {
+		t.Errorf("version = %q", info.Identity["version"])
+	}
+	if info.Identity["category"] == "" {
+		t.Error("the product category should be reported")
+	}
+}
+
+func TestGetSlotInfo_OutOfRange(t *testing.T) {
+	h := newHarness(t, nil)
+
+	if _, err := h.plugin.GetSlotInfo(context.Background(), 999); err == nil {
+		t.Error("a slot outside the port range should be refused")
+	}
+	if _, err := h.plugin.Walk(context.Background(), -1); err == nil {
+		t.Error("a negative slot should be refused")
+	}
+}
+
+// TestNotConnected covers every verb before Connect, because a caller that
+// forgot to connect should be told so rather than see a nil dereference.
+func TestNotConnected(t *testing.T) {
+	p := New(testDeps())
+	ctx := context.Background()
+
+	if _, err := p.GetDeviceInfo(ctx); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("GetDeviceInfo err = %v, want ErrNotConnected", err)
+	}
+	if _, err := p.GetSlotInfo(ctx, 0); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("GetSlotInfo err = %v, want ErrNotConnected", err)
+	}
+	if _, err := p.Walk(ctx, 0); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("Walk err = %v, want ErrNotConnected", err)
+	}
+	if _, err := p.GetValue(ctx, consumer.ValueRequest{Label: "x"}); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("GetValue err = %v, want ErrNotConnected", err)
+	}
+	if _, err := p.SetValue(ctx, consumer.ValueRequest{Label: "x"}, consumer.Value{}); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("SetValue err = %v, want ErrNotConnected", err)
+	}
+	if err := p.Subscribe(consumer.ValueRequest{}, func(consumer.Event) {}); !errors.Is(err, consumer.ErrNotConnected) {
+		t.Errorf("Subscribe err = %v, want ErrNotConnected", err)
+	}
+	// Disconnecting something that was never connected is not an error.
+	if err := p.Disconnect(); err != nil {
+		t.Errorf("Disconnect on a fresh plugin: %v", err)
+	}
+}
+
+// TestDisconnect_TerminatesSessions covers the rule that keeps units usable.
+// Servers do not time idle sessions out, so one we abandon is held until the
+// unit reboots, and a unit that runs out stops answering anybody.
+func TestDisconnect_TerminatesSessions(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	if _, err := h.plugin.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	h.device.mu.Lock()
+	before := len(h.device.sessions)
+	h.device.mu.Unlock()
+	if before == 0 {
+		t.Fatal("no sessions were opened")
+	}
+
+	if err := h.plugin.Disconnect(); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		left := len(h.device.sessions)
+		h.device.mu.Unlock()
+		if left == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d sessions were left open on the device", left)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestReconnect covers Connect being called twice, which the neutral contract
+// requires. The old link and its sessions go first.
+func TestReconnect(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if err := h.plugin.Connect(ctx, "10.6.250.105", DefaultPort); err != nil {
+		t.Fatalf("reconnect: %v", err)
+	}
+
+	// The new connection works, and the cached menu from the old one is gone
+	// rather than being reported for a device that may have changed.
+	if _, err := h.plugin.GetDeviceInfo(ctx); err != nil {
+		t.Fatalf("GetDeviceInfo after reconnect: %v", err)
+	}
+}
+
+func hasEvent(p *Plugin, name string) bool {
+	for _, e := range p.ComplianceEvents() {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/snell-rollcall/consumer/coverage_test.go
+++ b/internal/snell-rollcall/consumer/coverage_test.go
@@ -1,0 +1,505 @@
+package rollcall
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// The tests here close the last paths a device can take that the ordinary ones
+// do not reach: a link that goes away at an awkward moment, a file service that
+// gives up half way, a peer that says one thing in a header and another in the
+// payload.
+
+// TestSessionOnAClosedLink covers the check a caller meets when the link went
+// away before it asked. It is set directly rather than through Disconnect,
+// because Disconnect also removes the link from the plugin and the caller
+// would then never reach this path.
+func TestSessionOnAClosedLink(t *testing.T) {
+	h := newHarness(t, nil)
+
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+
+	l.mu.Lock()
+	l.closed = true
+	l.mu.Unlock()
+
+	if _, err := h.plugin.session(context.Background(), 1); err == nil {
+		t.Error("opening a session on a closed link should fail")
+	}
+	if _, err := h.plugin.fileSession(context.Background(), 0); err == nil {
+		t.Error("opening a file session on a closed link should fail")
+	}
+}
+
+// TestLinkClosesWhileASessionIsOpening covers the other side of that check: the
+// link is finished with between the call going out and its answer arriving.
+//
+// The session the peer just granted has to be closed rather than handed to the
+// caller, or a unit is left holding one that nothing will ever release.
+func TestLinkClosesWhileASessionIsOpening(t *testing.T) {
+	tests := []struct {
+		name string
+		open func(*Plugin) error
+	}{
+		{"control", func(p *Plugin) error {
+			_, err := p.session(context.Background(), 1)
+			return err
+		}},
+		{"file", func(p *Plugin) error {
+			_, err := p.fileSession(context.Background(), 0)
+			return err
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gate := make(chan struct{})
+			h := newHarness(t, func(d *device) { d.gateCall = gate })
+
+			done := make(chan error, 1)
+			go func() { done <- tc.open(h.plugin) }()
+
+			waitForCalls(t, h, 1)
+
+			// Mark the link finished without closing the socket, so the call
+			// still completes and the answer still arrives.
+			h.plugin.mu.RLock()
+			l := h.plugin.link
+			h.plugin.mu.RUnlock()
+			l.mu.Lock()
+			l.closed = true
+			l.mu.Unlock()
+
+			close(gate)
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Error("a session granted after the link finished must not be handed out")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("the caller was left waiting")
+			}
+		})
+	}
+}
+
+func waitForCalls(t *testing.T, h *harness, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.device.mu.Lock()
+		seen := h.device.callsSeen
+		h.device.mu.Unlock()
+		if seen >= n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d of %d calls arrived", seen, n)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestGetValueRefused covers a device refusing a read outright, which is what
+// "not at your user level" looks like on the control service.
+func TestGetValueRefused(t *testing.T) {
+	for _, gen := range generations() {
+		t.Run(gen.name, func(t *testing.T) {
+			typ := codec.MsgGetValue
+			if !gen.long {
+				typ = codec.MsgGetFStat
+			}
+			h := newHarness(t, func(d *device) {
+				gen.setup(d)
+				d.setMenu(1, testMenu())
+				d.refuse[typ] = true
+			})
+
+			_, err := h.plugin.GetValue(context.Background(),
+				consumer.ValueRequest{Slot: 1, Label: "Gain"})
+			if err == nil {
+				t.Error("a refused read should reach the caller")
+			}
+		})
+	}
+}
+
+// TestSetValueRefusesRawData covers writing bytes to a command. The protocol
+// carries raw data on a write, but which bytes mean what belongs to the
+// command set rather than to a generic connector, so it is refused rather than
+// guessed at.
+func TestSetValueRefusesRawData(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	_, err := h.plugin.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		consumer.Value{Kind: consumer.KindRaw, Raw: []byte{1, 2, 3}})
+	if err == nil {
+		t.Fatal("writing raw data should be refused rather than sent as a number")
+	}
+	if !strings.Contains(err.Error(), "raw") {
+		t.Errorf("err = %v, want it to say what was refused", err)
+	}
+}
+
+// TestSetValueStringTooLongForTheWire covers a caller writing a string longer
+// than even the long-string generation carries. It fails locally rather than
+// being cut without the caller knowing.
+func TestSetValueStringTooLongForTheWire(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	long := strings.Repeat("x", codec.MaxLongString+10)
+	_, err := h.plugin.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Label: "Name"},
+		consumer.Value{Kind: consumer.KindString, Str: long})
+	if err == nil {
+		t.Fatal("a string past the long-string ceiling should be refused")
+	}
+}
+
+// TestSetValueTruncatesForTheOlderGeneration covers the same string on a
+// 16-bit session, where truncation is what the protocol requires: the field is
+// twenty bytes and there is no other way to carry a label at all.
+func TestSetValueTruncatesForTheOlderGeneration(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services &^= codec.SvcLongStr
+		d.setMenu(1, testMenu())
+	})
+
+	long := strings.Repeat("x", 100)
+	got, err := h.plugin.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Label: "Name"},
+		consumer.Value{Kind: consumer.KindString, Str: long})
+	if err != nil {
+		t.Fatalf("a long string must be cut to the field, not refused: %v", err)
+	}
+	if len(got.Str) > codec.MaxTextSize-1 {
+		t.Errorf("the device stored %d bytes, more than the field holds", len(got.Str))
+	}
+}
+
+// TestSubscribeByLabelWithoutAMenu covers subscribing to a named object on a
+// device whose menu cannot be read. There is no way to turn the name into a
+// command, so it fails rather than subscribing to nothing.
+func TestSubscribeByLabelWithoutAMenu(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetMenuCount] = true })
+	req := consumer.ValueRequest{Slot: 1, Label: "Gain"}
+
+	if err := h.plugin.Subscribe(req, func(consumer.Event) {}); err == nil {
+		t.Error("subscribing by name with no menu should fail")
+	}
+	if err := h.plugin.Unsubscribe(req); err == nil {
+		t.Error("unsubscribing by name with no menu should fail")
+	}
+}
+
+// TestDeliveryStopsWhenTheSessionCloses covers the push pump ending when its
+// session goes, rather than spinning on a closed channel.
+func TestDeliveryStopsWhenTheSessionCloses(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(consumer.Event) {}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// Close the session out from under the pump. Its push channel closes,
+	// which is the pump's signal to stop.
+	s, err := h.plugin.session(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("session: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Nothing hangs and nothing panics; a later push simply goes nowhere.
+	h.device.push(1, codec.MsgDispData, nil)
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestAcknowledgementFailureStopsDelivery covers the link dying between a push
+// being taken and its acknowledgement being sent. There is nothing left to
+// acknowledge on, so the pump stops rather than looping on a dead socket.
+func TestAcknowledgementFailureStopsDelivery(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	delivered := make(chan struct{}, 4)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(consumer.Event) {
+			// The device goes away while the callback runs, so the
+			// acknowledgement that follows has nowhere to go.
+			h.device.close()
+			delivered <- struct{}{}
+		}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	value, err := codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 1}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetValue, value)
+
+	select {
+	case <-delivered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the push was never delivered")
+	}
+}
+
+// TestPushOnTheOlderGeneration covers a value push in the 16-bit form, which
+// is a different message from the 32-bit one and takes a different path.
+func TestPushOnTheOlderGeneration(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services &^= codec.SvcLongStr
+		d.setMenu(1, testMenu())
+	})
+
+	events := make(chan consumer.Event, 4)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	payload, err := codec.FuncStatus{
+		Command: 0x0113,
+		Mode:    codec.ModeValue,
+		Value:   -18,
+	}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetFStat, payload)
+
+	select {
+	case ev := <-events:
+		if ev.ID != 0x0113 || ev.Value.Int != -18 {
+			t.Errorf("= id %d value %d, want 275 and -18", ev.ID, ev.Value.Int)
+		}
+		if ev.Label != "Gain" {
+			t.Errorf("label = %q", ev.Label)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a 16-bit value push was not delivered")
+	}
+}
+
+// TestDisplayPushWithNoSlotListener covers a status line arriving when only a
+// single object is subscribed. A display line belongs to the unit rather than
+// to any command, so it goes to a listener for the whole slot or nowhere.
+func TestDisplayPushWithNoSlotListener(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 4)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	line, err := codec.Disp{Line: 0, Text: "OK"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgDispData, line)
+
+	select {
+	case ev := <-events:
+		t.Errorf("a display line reached a listener for one command: %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestDeviceMapEntryUndecodable covers a gateway answering its own map with a
+// device record too short to read.
+func TestDeviceMapEntryUndecodable(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.badMapEntry = true })
+
+	if _, err := h.plugin.Devices(context.Background()); err == nil {
+		t.Error("an undecodable map entry should be an error")
+	}
+}
+
+// TestDirectoryListingSkipsUnexpectedItems covers a device answering one entry
+// of a listing with something that is not a directory record.
+func TestDirectoryListingSkipsUnexpectedItems(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", []byte("x"))
+		d.setFile("B.BIN", []byte("y"))
+		d.oddDirItem = 0
+	})
+
+	entries, err := h.plugin.ListDir(context.Background(), 0, "/")
+	if err != nil {
+		t.Fatalf("ListDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("listed %d entries, want the listing less the odd one", len(entries))
+	}
+}
+
+// TestReadFileFailsPartWay covers a device that opens a file, hands over some
+// of it and then reports an error. What arrived is discarded: half a template
+// archive is worse than none, because it looks like a file.
+func TestReadFileFailsPartWay(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.blockSize = 8
+		d.setFile("A.BIN", bytes.Repeat([]byte("x"), 64))
+		d.failReadAfter = 2
+	})
+	ctx := context.Background()
+
+	if _, err := h.plugin.ReadFile(ctx, 0, "A.BIN"); err == nil {
+		t.Error("a read that failed part way should be an error")
+	}
+
+	h2 := newHarness(t, func(d *device) {
+		d.blockSize = 8
+		d.setFile("A.BIN", bytes.Repeat([]byte("x"), 64))
+		d.failReadAfter = 2
+	})
+	if _, err := h2.plugin.ReadFileTo(ctx, 0, "A.BIN", &bytes.Buffer{}); err == nil {
+		t.Error("the streaming form should fail too")
+	}
+}
+
+// TestReadHonoursTheReplyCount covers a device whose reply carries more bytes
+// than it says it read.
+//
+// The count is what a client must believe. Taking the whole payload instead
+// would append bytes the device did not mean to send, and a template archive
+// with extra bytes in the middle of it fails to open with no clue why.
+func TestReadHonoursTheReplyCount(t *testing.T) {
+	body := bytes.Repeat([]byte("abcdefgh"), 4)
+	h := newHarness(t, func(d *device) {
+		d.blockSize = 8
+		d.shortReadCount = true
+		d.setFile("A.BIN", body)
+	})
+
+	got, err := h.plugin.ReadFile(context.Background(), 0, "A.BIN")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	// The file still arrives whole, and that is the proof. Advancing by the
+	// count the device gave means the byte it declined to count is simply
+	// asked for again on the next block. Taking the whole payload while
+	// advancing by the count would duplicate a byte per block, and the result
+	// would be longer than the file and wrong in the middle.
+	if !bytes.Equal(got, body) {
+		t.Errorf("read %d bytes, want the file's %d, and they differ", len(got), len(body))
+	}
+}
+
+// TestReadFileStopsRunningAway covers a device that never reaches the end of a
+// file. Without a ceiling the read would consume memory until the process
+// died, which is a worse failure than saying the device is not stopping.
+func TestReadFileStopsRunningAway(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", bytes.Repeat([]byte("x"), 64))
+		d.endlessFile = true
+	})
+	h.plugin.fileCeiling = 4096
+
+	_, err := h.plugin.ReadFile(context.Background(), 0, "A.BIN")
+	if err == nil {
+		t.Fatal("a file that never ends should be refused")
+	}
+	if !strings.Contains(err.Error(), "not stopping") {
+		t.Errorf("err = %v, want it to name the device's behaviour", err)
+	}
+}
+
+func TestMaxFileBytesDefault(t *testing.T) {
+	p := New(testDeps())
+	if p.maxFileBytes() != DefaultMaxFileBytes {
+		t.Errorf("= %d, want the default %d", p.maxFileBytes(), DefaultMaxFileBytes)
+	}
+	p.fileCeiling = 1024
+	if p.maxFileBytes() != 1024 {
+		t.Errorf("= %d, want the ceiling a caller set", p.maxFileBytes())
+	}
+}
+
+// TestResolveAPathThatIsALabel covers a caller writing a label where a path is
+// expected, which is what happens whenever an object sits at the top of a menu
+// and its path and its label are the same word.
+func TestResolveAPathThatIsALabel(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 11})
+	})
+
+	v, err := h.plugin.GetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, Path: "Gain"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if v.Int != 11 {
+		t.Errorf("= %d, want 11", v.Int)
+	}
+}
+
+// TestUnitFromFormatWithNoConversion covers a format string that opens a
+// conversion and never finishes it, which a device with a truncated template
+// produces.
+func TestUnitFromFormatWithNoConversion(t *testing.T) {
+	for _, in := range []string{"%", "%-", "%0."} {
+		if got := unitFromFormat(in); got != "" {
+			t.Errorf("unitFromFormat(%q) = %q, want no unit", in, got)
+		}
+	}
+}
+
+// TestGetValueByLabelWithoutAMenu covers naming an object on a device whose
+// menu cannot be read. The session opens, so the failure is the menu's, and a
+// name cannot be turned into a command without one.
+func TestGetValueByLabelWithoutAMenu(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetMenuCount] = true })
+	ctx := context.Background()
+
+	if _, err := h.plugin.GetValue(ctx, consumer.ValueRequest{Slot: 1, Label: "Gain"}); err == nil {
+		t.Error("reading by name with no menu should fail")
+	}
+	if _, err := h.plugin.SetValue(ctx, consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		consumer.Value{Kind: consumer.KindInt, Int: 1}); err == nil {
+		t.Error("writing by name with no menu should fail")
+	}
+}
+
+// TestUnsubscribeAfterTheDeviceWentAway covers removing the last subscription
+// from a slot we can no longer reach.
+//
+// There is nothing left to tell the device, and saying so would be noise: the
+// subscription is gone from our side either way, and a device that is not
+// there is not still pushing.
+func TestUnsubscribeAfterTheDeviceWentAway(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	req := consumer.ValueRequest{Slot: 1}
+
+	if err := h.plugin.Subscribe(req, func(consumer.Event) {}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := h.plugin.Disconnect(); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	if err := h.plugin.Unsubscribe(req); err != nil {
+		t.Errorf("unsubscribing from a device that has gone: %v", err)
+	}
+
+	h.plugin.mu.RLock()
+	left := len(h.plugin.subs)
+	h.plugin.mu.RUnlock()
+	if left != 0 {
+		t.Errorf("%d subscriptions were left behind", left)
+	}
+}

--- a/internal/snell-rollcall/consumer/device_test.go
+++ b/internal/snell-rollcall/consumer/device_test.go
@@ -103,6 +103,26 @@ type device struct {
 	// itself, which is what a freshly started one does.
 	emptyDeviceMap bool
 
+	// badMapEntry makes the device map answer with a device record too short
+	// to decode.
+	badMapEntry bool
+
+	// oddDirItem makes one entry of a directory listing come back as
+	// something other than a directory record.
+	oddDirItem int
+
+	// failReadAfter makes a file read report an error once that many chunks
+	// have been handed over. Negative disables it.
+	failReadAfter int
+
+	// shortReadCount makes a read reply claim fewer bytes than it actually
+	// carries, which a client must believe over the payload it can see.
+	shortReadCount bool
+
+	// endlessFile makes every read return data and never end, which is what a
+	// device stuck in a loop looks like.
+	endlessFile bool
+
 	// garbleDirEntry truncates the entries of a directory listing. It is
 	// separate from garble because the items of a multi-packet transfer all
 	// arrive as answers to the same request type, so the type alone cannot
@@ -117,23 +137,25 @@ type device struct {
 
 func newDevice(t *testing.T, conn net.Conn) *device {
 	d := &device{
-		t:           t,
-		services:    codec.SvcMenus | codec.SvcControl | codec.SvcDisplay | codec.SvcFile | codec.SvcLongStr,
-		menus:       make(map[uint8][]codec.MenuItem),
-		values:      make(map[uint8]map[uint32]codec.Value),
-		files:       make(map[string][]byte),
-		identity:    make(map[uint8]codec.ID),
-		ports:       2,
-		blockSize:   0,
-		sessions:    make(map[int16]uint8),
-		nextIdx:     0x30,
-		backChannel: make(map[int16]bool),
-		oddMenuItem: -1,
-		oddListItem: -1,
-		refuse:      make(map[codec.PacketType]bool),
-		garble:      make(map[codec.PacketType]bool),
-		conn:        conn,
-		done:        make(chan struct{}),
+		t:             t,
+		services:      codec.SvcMenus | codec.SvcControl | codec.SvcDisplay | codec.SvcFile | codec.SvcLongStr,
+		menus:         make(map[uint8][]codec.MenuItem),
+		values:        make(map[uint8]map[uint32]codec.Value),
+		files:         make(map[string][]byte),
+		identity:      make(map[uint8]codec.ID),
+		ports:         2,
+		blockSize:     0,
+		sessions:      make(map[int16]uint8),
+		nextIdx:       0x30,
+		backChannel:   make(map[int16]bool),
+		oddMenuItem:   -1,
+		oddListItem:   -1,
+		oddDirItem:    -1,
+		failReadAfter: -1,
+		refuse:        make(map[codec.PacketType]bool),
+		garble:        make(map[codec.PacketType]bool),
+		conn:          conn,
+		done:          make(chan struct{}),
 	}
 	go d.serve()
 	return d

--- a/internal/snell-rollcall/consumer/device_test.go
+++ b/internal/snell-rollcall/consumer/device_test.go
@@ -1,0 +1,349 @@
+package rollcall
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/clock"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/transport"
+)
+
+// The consumer is tested against a fake RollCall device rather than a mock of
+// its own session layer. That is the point: the device speaks the wire format,
+// so a test failure means the bytes are wrong, not that an expectation was
+// written differently from the code.
+//
+// It runs over net.Pipe with an injected clock, so there is no socket, no port
+// and no sleeping anywhere.
+
+// gatewayAddr is the unit the fake device presents as.
+var gatewayAddr = codec.Address{Unit: 0x08, Port: 0x00, Index: codec.IndexUnknown}
+
+// device is a RollCall server good enough to drive the consumer.
+type device struct {
+	t *testing.T
+
+	mu sync.Mutex
+
+	// services is what the gateway advertises, which decides which
+	// generation the consumer will ask for.
+	services codec.Service
+
+	// menus is the menu each port serves.
+	menus map[uint8][]codec.MenuItem
+
+	// values is the current value of each command, per port.
+	values map[uint8]map[uint32]codec.Value
+
+	// files is what the file service serves.
+	files map[string][]byte
+
+	// identity is what each port reports.
+	identity map[uint8]codec.ID
+
+	// ports is how many ports the device list reports.
+	ports int
+
+	// refuseLongStrings makes the device advertise long strings and then
+	// refuse a call that asks for them, which is a real deviation.
+	refuseLongStrings bool
+
+	// blockSize is what an open reports as its maximum read size.
+	blockSize int32
+
+	// sessions maps our index to the port it was opened on.
+	sessions map[int16]uint8
+	nextIdx  int16
+
+	// backChannel records which sessions asked for pushes.
+	backChannel map[int16]bool
+
+	// blocks is the state a multi-packet transfer needs, per session. The
+	// 16-bit form is stateful by design: a fetch names an offset from the
+	// base of the request that opened the transfer.
+	blocks map[int16]*blockState
+
+	// openFiles is what the file service has handed out handles for.
+	openFiles map[int16][]byte
+
+	// refuse makes the device answer a message type with Nack, so a test can
+	// see what the connector does when a device says no.
+	refuse map[codec.PacketType]bool
+
+	// garble makes the device answer a message type with a payload too short
+	// to decode, which is what a firmware bug looks like from outside.
+	garble map[codec.PacketType]bool
+
+	// gateCall holds every Call until a test releases it, so two callers can
+	// be made to race for the same port deterministically.
+	gateCall chan struct{}
+
+	// callsSeen counts the Calls that arrived, so a test can wait for both
+	// racers to be in flight before releasing them.
+	callsSeen int
+
+	// oddMenuItem makes one item of a 16-bit menu transfer come back as
+	// something other than a menu line, which a walker should skip rather
+	// than abandon the menu for. Negative disables it.
+	oddMenuItem int
+
+	// oddListItem makes one item of a device or port list come back as
+	// something other than a device record, which a walker should skip.
+	oddListItem int
+
+	// emptyDeviceMap makes the gateway report having heard nothing announce
+	// itself, which is what a freshly started one does.
+	emptyDeviceMap bool
+
+	// garbleDirEntry truncates the entries of a directory listing. It is
+	// separate from garble because the items of a multi-packet transfer all
+	// arrive as answers to the same request type, so the type alone cannot
+	// say which transfer to spoil.
+	garbleDirEntry bool
+
+	conn net.Conn
+	w    sync.Mutex
+	done chan struct{}
+	once sync.Once
+}
+
+func newDevice(t *testing.T, conn net.Conn) *device {
+	d := &device{
+		t:           t,
+		services:    codec.SvcMenus | codec.SvcControl | codec.SvcDisplay | codec.SvcFile | codec.SvcLongStr,
+		menus:       make(map[uint8][]codec.MenuItem),
+		values:      make(map[uint8]map[uint32]codec.Value),
+		files:       make(map[string][]byte),
+		identity:    make(map[uint8]codec.ID),
+		ports:       2,
+		blockSize:   0,
+		sessions:    make(map[int16]uint8),
+		nextIdx:     0x30,
+		backChannel: make(map[int16]bool),
+		oddMenuItem: -1,
+		oddListItem: -1,
+		refuse:      make(map[codec.PacketType]bool),
+		garble:      make(map[codec.PacketType]bool),
+		conn:        conn,
+		done:        make(chan struct{}),
+	}
+	go d.serve()
+	return d
+}
+
+// setMenu gives a port a menu and seeds a value for every command in it.
+func (d *device) setMenu(port uint8, items []codec.MenuItem) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.menus[port] = items
+	if d.values[port] == nil {
+		d.values[port] = make(map[uint32]codec.Value)
+	}
+	for _, m := range items {
+		if m.Command == 0 || m.Style.Container() {
+			continue
+		}
+		if _, seen := d.values[port][m.Command]; seen {
+			continue
+		}
+		d.values[port][m.Command] = codec.Value{
+			Command: m.Command,
+			Mode:    codec.ModeValue,
+			Val:     m.MinRange,
+		}
+	}
+}
+
+func (d *device) setValue(port uint8, v codec.Value) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.values[port] == nil {
+		d.values[port] = make(map[uint32]codec.Value)
+	}
+	d.values[port][v.Command] = v
+}
+
+func (d *device) setFile(path string, body []byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.files[path] = body
+}
+
+func (d *device) close() {
+	d.once.Do(func() {
+		close(d.done)
+		_ = d.conn.Close()
+	})
+}
+
+// serve reads frames and answers them.
+func (d *device) serve() {
+	r := codec.NewReader(d.conn)
+	for {
+		f, err := r.ReadFrame()
+		if err != nil {
+			return
+		}
+		f.Payload = append([]byte(nil), f.Payload...)
+		d.handle(f)
+	}
+}
+
+func (d *device) reply(req codec.Frame, typ codec.PacketType, payload []byte) {
+	d.send(codec.Frame{
+		Dst:     req.Src,
+		Src:     req.Dst,
+		Type:    typ,
+		Payload: payload,
+	})
+}
+
+func (d *device) send(f codec.Frame) {
+	b, err := f.Encode()
+	if err != nil {
+		return
+	}
+	d.w.Lock()
+	defer d.w.Unlock()
+	select {
+	case <-d.done:
+		return
+	default:
+	}
+	if _, err := d.conn.Write(b); err != nil && err != io.ErrClosedPipe {
+		return
+	}
+}
+
+// push sends a back-channel message to whoever is subscribed on a port.
+func (d *device) push(port uint8, typ codec.PacketType, payload []byte) {
+	d.mu.Lock()
+	var targets []int16
+	for idx, p := range d.sessions {
+		if p == port && d.backChannel[idx] {
+			targets = append(targets, idx)
+		}
+	}
+	d.mu.Unlock()
+
+	for _, idx := range targets {
+		d.send(codec.Frame{
+			Dst:     codec.Address{Unit: 0, Port: 0xE0, Index: idx},
+			Src:     codec.Address{Unit: gatewayAddr.Unit, Port: port, Index: idx},
+			Type:    typ,
+			Flags:   codec.FlagBackChannel,
+			Payload: payload,
+		})
+	}
+}
+
+// harness is a plugin connected to a fake device.
+type harness struct {
+	plugin *Plugin
+	device *device
+	clk    *clock.Fake
+}
+
+// pipeNet is a transport whose Dial hands back one end of a pipe. It is what
+// keeps the consumer from opening a socket in a test while still going through
+// the same code path it uses in service.
+type pipeNet struct {
+	t  *testing.T
+	mu sync.Mutex
+	fn func() net.Conn
+}
+
+func (p *pipeNet) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.fn(), nil
+}
+
+func (p *pipeNet) Listen(context.Context, string, string) (net.Listener, error) {
+	p.t.Fatal("the consumer must never listen")
+	return nil, nil
+}
+
+func (p *pipeNet) ListenPacket(context.Context, string, string) (net.PacketConn, error) {
+	p.t.Fatal("the consumer must never bind a datagram socket")
+	return nil, nil
+}
+
+var _ transport.Net = (*pipeNet)(nil)
+
+// newHarness builds a plugin wired to a fake device, and connects it.
+func newHarness(t *testing.T, setup func(*device)) *harness {
+	t.Helper()
+
+	clk := clock.NewFake(time.Time{})
+	var dev *device
+
+	dialer := &pipeNet{t: t}
+	dialer.fn = func() net.Conn {
+		ours, theirs := net.Pipe()
+		dev = newDevice(t, theirs)
+		if setup != nil {
+			setup(dev)
+		}
+		return ours
+	}
+
+	p := New(plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Net:     dialer,
+		Clock:   clk,
+		Metrics: metrics.NewConnector(),
+	})
+
+	if err := p.Connect(context.Background(), "10.6.250.105", DefaultPort); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	h := &harness{plugin: p, device: dev, clk: clk}
+	t.Cleanup(func() {
+		_ = p.Disconnect()
+		if h.device != nil {
+			h.device.close()
+		}
+	})
+	return h
+}
+
+// menu builds a small but realistic menu: a container with three lines under
+// it, which is enough to exercise the tree spans, and one line of each kind
+// that maps differently.
+func testMenu() []codec.MenuItem {
+	return []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleList, Step: 3, Text: "Video"},
+		{MenuIndex: 1, Style: codec.StyleNumber, Command: 0x0113,
+			MinRange: -60, MaxRange: 6, Step: 1, DivScale: 10, Text: "Gain", Param: "%0.1f dB"},
+		{MenuIndex: 2, Style: codec.StyleCheckbox, Command: 0x0114,
+			MinRange: 1, Text: "Enable"},
+		{MenuIndex: 3, Style: codec.StyleEditString, Command: 0x0115,
+			MaxRange: 32, Text: "Name"},
+		{MenuIndex: 4, Style: codec.StyleDisplay, Command: 0x0116, Text: "Status"},
+	}
+}
+
+// timeoutAfter is the wait for something that should already have happened.
+// It bounds a test rather than pacing one: nothing under test is waiting on
+// protocol time here.
+func timeoutAfter() <-chan time.Time { return time.After(2 * time.Second) }
+
+// testDeps is the dependency set for a plugin with no device behind it.
+func testDeps() plugin.Deps {
+	return plugin.Deps{
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Clock:   clock.NewFake(time.Time{}),
+		Metrics: metrics.NewConnector(),
+	}
+}

--- a/internal/snell-rollcall/consumer/devicehandler_test.go
+++ b/internal/snell-rollcall/consumer/devicehandler_test.go
@@ -1,0 +1,684 @@
+package rollcall
+
+import (
+	"sort"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// handle answers one request the way a RollCall server would.
+//
+// It is deliberately a server rather than a script of expected messages: a
+// test that drives it exercises the same bytes a device would see, so a wrong
+// field is a failure rather than a rewritten expectation.
+func (d *device) handle(f codec.Frame) {
+	d.mu.Lock()
+	refuse, garble := d.refuse[f.Type], d.garble[f.Type]
+	d.mu.Unlock()
+
+	if refuse {
+		d.reply(f, codec.MsgNack, []byte{'r', 'e', 'f', 'u', 's', 'e', 'd', 0})
+		return
+	}
+	if garble {
+		// A payload too short for the structure it claims to be. A device
+		// with a firmware fault looks exactly like this from outside.
+		d.reply(f, replyTypeFor(f.Type), []byte{0x01})
+		return
+	}
+
+	switch f.Type {
+	case codec.MsgGetDevInfo:
+		d.handshake(f)
+	case codec.MsgCall:
+		d.call(f)
+	case codec.MsgTerm:
+		d.term(f)
+	case codec.MsgKeepAlive:
+		d.reply(f, codec.MsgAck, nil)
+
+	case codec.MsgGetID:
+		d.getID(f)
+	case codec.MsgGetStat:
+		d.getStat(f)
+	case codec.MsgGetDevList:
+		d.deviceList(f)
+	case codec.MsgGetLocDevMap:
+		d.deviceMap(f)
+
+	case codec.MsgGetMenuCount:
+		d.menuCount(f)
+	case codec.MsgGetMenuItem:
+		d.menuItem(f)
+	case codec.MsgGetFunc:
+		d.menuBlock(f)
+	case codec.MsgGetNextPkt:
+		d.menuNext(f)
+
+	case codec.MsgGetValue:
+		d.getValue(f)
+	case codec.MsgSetValue:
+		d.setValueMsg(f)
+	case codec.MsgGetFStat:
+		d.getFStat(f)
+	case codec.MsgSetParam:
+		d.setParam(f)
+
+	case codec.MsgGetDispData:
+		d.dispData(f)
+	case codec.MsgBkChnReady:
+		d.backChannelReady(f)
+	case codec.MsgRepFChg:
+		d.reply(f, codec.MsgAck, nil)
+
+	case codec.MsgFileOpen:
+		d.fileOpen(f)
+	case codec.MsgFileRead:
+		d.fileRead(f)
+	case codec.MsgFileDir:
+		d.fileDir(f)
+	case codec.MsgFileClose:
+		d.reply(f, codec.MsgFileRet, codec.File{}.AppendTo(nil))
+
+	case codec.MsgAck:
+		// An acknowledgement of one of our pushes. Nothing to do.
+
+	default:
+		// A server answers what it does not implement with InvCmd, which is
+		// different from refusing: it means "I do not know this message".
+		d.reply(f, codec.MsgInvCmd, nil)
+	}
+}
+
+// replyTypeFor names the answer a request expects, so a garbled reply is the
+// right type with the wrong contents rather than an obviously wrong message.
+func replyTypeFor(req codec.PacketType) codec.PacketType {
+	switch req {
+	case codec.MsgGetDevInfo, codec.MsgGetDevList, codec.MsgGetLocDevMap:
+		return codec.MsgRetDevInfo
+	case codec.MsgGetID:
+		return codec.MsgRetID
+	case codec.MsgGetStat:
+		return codec.MsgRetStat
+	case codec.MsgGetMenuCount:
+		return codec.MsgRetMenuCount
+	case codec.MsgGetMenuItem:
+		return codec.MsgRetMenuItem
+	case codec.MsgGetFunc:
+		return codec.MsgBlockHeader
+	case codec.MsgGetNextPkt:
+		return codec.MsgRetFunc
+	case codec.MsgGetValue, codec.MsgSetValue:
+		return codec.MsgRetValue
+	case codec.MsgGetFStat, codec.MsgSetParam:
+		return codec.MsgRetFStat
+	case codec.MsgGetDispData:
+		return codec.MsgDispData
+	case codec.MsgFileOpen:
+		return codec.MsgRetFileOpen
+	case codec.MsgFileRead:
+		return codec.MsgRetFileRead
+	case codec.MsgFileDir:
+		return codec.MsgBlockHeader
+	default:
+		return codec.MsgAck
+	}
+}
+
+func (d *device) handshake(f codec.Frame) {
+	d.mu.Lock()
+	services := d.services
+	d.mu.Unlock()
+
+	info := codec.DeviceInfo{
+		ProtocolVersion: codec.ProtocolVersion,
+		Address:         gatewayAddr,
+		ID: codec.ID{
+			Services: services,
+			TypeID:   636,
+			Version:  codec.Version{Major: 1, Minor: 2, Alpha: ' ', CmdSet: 1},
+			Name:     "Centra",
+		},
+		Status: codec.UnitStatus{Status: codec.StatusPresent | codec.StatusOnline},
+	}
+	payload, err := info.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode device info: %v", err)
+		return
+	}
+
+	// The gateway stamps the client's address into the destination, which is
+	// how a TCP client learns what it is called.
+	d.send(codec.Frame{
+		Dst:     codec.Address{Unit: 0, Port: 0xE0, Index: f.Src.Index},
+		Src:     gatewayAddr,
+		Type:    codec.MsgRetDevInfo,
+		Payload: payload,
+	})
+}
+
+func (d *device) call(f codec.Frame) {
+	d.mu.Lock()
+	d.callsSeen++
+	gate := d.gateCall
+	d.mu.Unlock()
+
+	// A held call waits off the read loop. Blocking the loop instead would
+	// stop the second caller's request ever being read, which is the race the
+	// gate exists to create.
+	if gate != nil {
+		go func() {
+			<-gate
+			d.answerCall(f)
+		}()
+		return
+	}
+	d.answerCall(f)
+}
+
+func (d *device) answerCall(f codec.Frame) {
+	conn, err := codec.DecodeConnect(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	refuse := d.refuseLongStrings && conn.Services.LongStrings()
+	if refuse {
+		d.mu.Unlock()
+		d.reply(f, codec.MsgNack, []byte("no long strings\x00"))
+		return
+	}
+	idx := d.nextIdx
+	d.nextIdx++
+	d.sessions[f.Src.Index] = f.Dst.Port
+	d.mu.Unlock()
+
+	d.send(codec.Frame{
+		Dst:  f.Src,
+		Src:  codec.Address{Unit: gatewayAddr.Unit, Port: f.Dst.Port, Index: idx},
+		Type: codec.MsgAck,
+	})
+}
+
+func (d *device) term(f codec.Frame) {
+	d.mu.Lock()
+	delete(d.sessions, f.Src.Index)
+	delete(d.backChannel, f.Src.Index)
+	d.mu.Unlock()
+}
+
+// port returns which port a session was opened on.
+func (d *device) port(f codec.Frame) uint8 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.sessions[f.Src.Index]
+}
+
+func (d *device) getID(f codec.Frame) {
+	port := d.port(f)
+
+	d.mu.Lock()
+	id, ok := d.identity[port]
+	d.mu.Unlock()
+
+	if !ok {
+		id = codec.ID{
+			Services: codec.SvcMenus | codec.SvcControl,
+			TypeID:   623,
+			Version:  codec.Version{Major: 2, Minor: 1, Alpha: 'a', CmdSet: 3},
+			Name:     "5915 Card",
+		}
+	}
+	payload, err := id.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode id: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetID, payload)
+}
+
+func (d *device) getStat(f codec.Frame) {
+	st := codec.UnitStatus{Status: codec.StatusPresent | codec.StatusOnline}
+	d.reply(f, codec.MsgRetStat, st.AppendTo(nil))
+}
+
+// deviceList answers a port enumeration with one entry per port.
+func (d *device) deviceList(f codec.Frame) {
+	d.mu.Lock()
+	n := d.ports
+	odd := d.oddListItem
+	d.mu.Unlock()
+
+	d.block(f, codec.MsgGetDevList, n, func(i int) (codec.PacketType, []byte) {
+		if i == odd {
+			return codec.MsgAck, nil
+		}
+		info := codec.DeviceInfo{
+			ProtocolVersion: codec.ProtocolVersion,
+			Address:         codec.Address{Unit: gatewayAddr.Unit, Port: uint8(i), Index: codec.IndexUnknown},
+			ID: codec.ID{
+				Services: codec.SvcMenus | codec.SvcControl,
+				TypeID:   623,
+				Name:     "Card",
+			},
+			Status: codec.UnitStatus{Status: codec.StatusPresent},
+		}
+		payload, _ := info.AppendTo(nil)
+		return codec.MsgRetDevInfo, payload
+	})
+}
+
+func (d *device) deviceMap(f codec.Frame) {
+	d.mu.Lock()
+	empty := d.emptyDeviceMap
+	d.mu.Unlock()
+
+	count := 1
+	if empty {
+		count = 0
+	}
+	odd := d.oddListItem
+	d.block(f, codec.MsgGetLocDevMap, count, func(i int) (codec.PacketType, []byte) {
+		if i == odd {
+			return codec.MsgAck, nil
+		}
+		info := codec.DeviceInfo{
+			ProtocolVersion: codec.ProtocolVersion,
+			Address:         gatewayAddr,
+			ID:              codec.ID{TypeID: 636, Name: "Centra"},
+			Status:          codec.UnitStatus{Status: codec.StatusPresent},
+		}
+		payload, _ := info.AppendTo(nil)
+		return codec.MsgRetDevInfo, payload
+	})
+}
+
+// block answers a multi-packet transfer: a header, then one item per fetch.
+type blockState struct {
+	count int
+	item  func(int) (codec.PacketType, []byte)
+}
+
+func (d *device) block(f codec.Frame, req codec.PacketType, count int, item func(int) (codec.PacketType, []byte)) {
+	d.mu.Lock()
+	if d.blocks == nil {
+		d.blocks = make(map[int16]*blockState)
+	}
+	d.blocks[f.Src.Index] = &blockState{count: count, item: item}
+	d.mu.Unlock()
+
+	hdr := codec.BlockHeader{PktType: req, Count: uint16(count), MaxSize: codec.MaxPayload}
+	d.reply(f, codec.MsgBlockHeader, hdr.AppendTo(nil))
+}
+
+func (d *device) menuNext(f codec.Frame) {
+	next, err := codec.DecodeGetNext(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	st := d.blocks[f.Src.Index]
+	d.mu.Unlock()
+
+	if st == nil || int(next.Index) >= st.count {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	typ, payload := st.item(int(next.Index))
+	d.reply(f, typ, payload)
+}
+
+// menuBlock answers the 16-bit menu request.
+func (d *device) menuBlock(f codec.Frame) {
+	port := d.port(f)
+
+	d.mu.Lock()
+	items := d.menus[port]
+	odd := d.oddMenuItem
+	d.mu.Unlock()
+
+	d.block(f, codec.MsgGetFunc, len(items), func(i int) (codec.PacketType, []byte) {
+		if i == odd {
+			// Not a menu line at all. A walker should skip it and keep the
+			// rest of the menu.
+			return codec.MsgAck, nil
+		}
+		fn, err := items[i].ToFunc()
+		if err != nil {
+			// A menu that cannot be narrowed is a menu this device should
+			// not have been asked for in this generation.
+			d.t.Errorf("device: line %d does not fit the 16-bit generation: %v", i, err)
+			return codec.MsgNack, nil
+		}
+		payload, _ := fn.AppendTo(nil)
+		return codec.MsgRetFunc, payload
+	})
+}
+
+func (d *device) menuCount(f codec.Frame) {
+	port := d.port(f)
+
+	d.mu.Lock()
+	items := d.menus[port]
+	d.mu.Unlock()
+
+	req, err := codec.DecodeMenuReq(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	size := codec.MenuSize{MenuIndex: req.MenuIndex, MenuCount: uint32(len(items))}
+	d.reply(f, codec.MsgRetMenuCount, size.AppendTo(nil))
+}
+
+func (d *device) menuItem(f codec.Frame) {
+	port := d.port(f)
+
+	req, err := codec.DecodeMenuReq(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	items := d.menus[port]
+	d.mu.Unlock()
+
+	if int(req.MenuIndex) >= len(items) {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	payload, err := items[req.MenuIndex].AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode menu item: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetMenuItem, payload)
+}
+
+func (d *device) getValue(f codec.Frame) {
+	port := d.port(f)
+
+	req, err := codec.DecodeGetValue(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	v, ok := d.values[port][req.Command]
+	d.mu.Unlock()
+
+	if !ok {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	payload, err := v.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode value: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetValue, payload)
+}
+
+// setValueMsg writes a value and answers with what the device stored, which is
+// how a caller learns that a device clamped what it asked for.
+func (d *device) setValueMsg(f codec.Frame) {
+	port := d.port(f)
+
+	v, err := codec.DecodeValue(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	stored := d.store(port, v)
+	payload, err := stored.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode value: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetValue, payload)
+}
+
+// store applies a write, clamping to the menu's range the way a device does.
+func (d *device) store(port uint8, v codec.Value) codec.Value {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if v.Mode.Has(codec.ModePreset) {
+		// A preset write asks for the device's own default, and the numeric
+		// field is ignored. The default here is the bottom of the range.
+		for _, m := range d.menus[port] {
+			if m.Command == v.Command {
+				v = codec.Value{Command: v.Command, Mode: codec.ModeValue, Val: m.MinRange}
+			}
+		}
+	} else {
+		for _, m := range d.menus[port] {
+			if m.Command != v.Command || !v.Mode.Has(codec.ModeValue) {
+				continue
+			}
+			// Only a numeric line has a range to clamp against. On a
+			// checkbox the minimum field is the "on" value and on a button it
+			// is the value the press writes, so clamping either would turn a
+			// legitimate write into its opposite.
+			switch m.Style.Kind() {
+			case codec.StyleNumber, codec.StyleVGraph, codec.StyleHGraph,
+				codec.StyleVLevel, codec.StyleHLevel:
+				if v.Val < m.MinRange {
+					v.Val = m.MinRange
+				}
+				if v.Val > m.MaxRange {
+					v.Val = m.MaxRange
+				}
+			}
+		}
+	}
+	if d.values[port] == nil {
+		d.values[port] = make(map[uint32]codec.Value)
+	}
+	d.values[port][v.Command] = v
+	return v
+}
+
+func (d *device) getFStat(f codec.Frame) {
+	port := d.port(f)
+
+	req, err := codec.DecodeGetFStat(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	v, ok := d.values[port][uint32(req.Command)]
+	d.mu.Unlock()
+
+	if !ok {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	fs, err := v.ToFuncStatus()
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	payload, err := fs.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode func status: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetFStat, payload)
+}
+
+func (d *device) setParam(f codec.Frame) {
+	port := d.port(f)
+
+	fs, err := codec.DecodeFuncStatus(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	stored := d.store(port, fs.ToValue())
+	back, err := stored.ToFuncStatus()
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	payload, err := back.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode func status: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgRetFStat, payload)
+}
+
+func (d *device) dispData(f codec.Frame) {
+	if len(f.Payload) < 2 {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	line := int16(uint16(f.Payload[0])<<8 | uint16(f.Payload[1]))
+	if line > 1 {
+		// This device only has two status lines, which is ordinary.
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	disp := codec.Disp{Line: line, Text: "line " + string(rune('0'+line))}
+	payload, err := disp.AppendTo(nil)
+	if err != nil {
+		d.t.Errorf("device: encode display: %v", err)
+		return
+	}
+	d.reply(f, codec.MsgDispData, payload)
+}
+
+func (d *device) backChannelReady(f codec.Frame) {
+	if len(f.Payload) != 1 {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+	d.mu.Lock()
+	d.backChannel[f.Src.Index] = f.Payload[0] != codec.BackChannelDisable
+	d.mu.Unlock()
+	d.reply(f, codec.MsgAck, nil)
+}
+
+func (d *device) fileOpen(f codec.Frame) {
+	req, path, err := codec.DecodeFileOpen(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	// A device serves binary files, and a client that forgot the flag would
+	// get line endings translated. Catching it here is what makes the
+	// consumer's insistence on the flag testable.
+	if req.OpenFlags()&codec.OpenBinary == 0 {
+		d.t.Errorf("device: %q was opened without the binary flag (%04X)", path, req.OpenFlags())
+	}
+
+	d.mu.Lock()
+	body, ok := d.files[path]
+	size := d.blockSize
+	d.mu.Unlock()
+
+	if !ok {
+		fail := codec.File{SrcHandle: req.SrcHandle, Extra: codec.FileErrNoEntry}
+		d.reply(f, codec.MsgRetFileOpen, fail.AppendTo(nil))
+		return
+	}
+
+	d.mu.Lock()
+	if d.openFiles == nil {
+		d.openFiles = make(map[int16][]byte)
+	}
+	handle := int16(len(d.openFiles) + 1)
+	d.openFiles[handle] = body
+	d.mu.Unlock()
+
+	// The reply overwrites both numeric fields: the offset becomes the
+	// device's own maximum read size, and the extra becomes the error.
+	ok2 := codec.File{SrcHandle: req.SrcHandle, FileHandle: handle, Offset: size}
+	d.reply(f, codec.MsgRetFileOpen, ok2.AppendTo(nil))
+}
+
+// fileDir answers a directory listing as a multi-packet transfer.
+func (d *device) fileDir(f codec.Frame) {
+	d.mu.Lock()
+	names := make([]string, 0, len(d.files))
+	for name := range d.files {
+		names = append(names, name)
+	}
+	sizes := make(map[string]int, len(d.files))
+	for name, body := range d.files {
+		sizes[name] = len(body)
+	}
+	garble := d.garbleDirEntry
+	d.mu.Unlock()
+	sort.Strings(names)
+
+	d.block(f, codec.MsgFileDir, len(names), func(i int) (codec.PacketType, []byte) {
+		if garble {
+			return codec.MsgRetFileDir, []byte{0x01}
+		}
+		entry := codec.DirEntry{
+			Info: codec.FileInfo{Length: int32(sizes[names[i]])},
+			Name: names[i],
+		}
+		payload, err := entry.AppendTo(nil)
+		if err != nil {
+			d.t.Errorf("device: encode directory entry: %v", err)
+			return codec.MsgNack, nil
+		}
+		return codec.MsgRetFileDir, payload
+	})
+}
+
+func (d *device) fileRead(f codec.Frame) {
+	req, err := codec.DecodeFile(f.Payload)
+	if err != nil {
+		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	body, ok := d.openFiles[req.FileHandle]
+	d.mu.Unlock()
+
+	if !ok {
+		fail := codec.File{SrcHandle: req.SrcHandle, Extra: codec.FileErrInvalid}
+		d.reply(f, codec.MsgRetFileRead, fail.AppendTo(nil))
+		return
+	}
+
+	// On a read the offset says where and the extra says how many. A client
+	// that sends a zero count would read nothing for ever, so the device
+	// says so rather than looping.
+	count := int(req.Extra)
+	if count <= 0 {
+		d.t.Errorf("device: a read asked for %d bytes; the count belongs in the extra field", count)
+		count = 0
+	}
+
+	off := int(req.Offset)
+	if off > len(body) {
+		off = len(body)
+	}
+	end := off + count
+	if end > len(body) {
+		end = len(body)
+	}
+	chunk := body[off:end]
+
+	// In the reply the offset is how many bytes were read and the extra is
+	// the error, which is the opposite of the request.
+	hdr := codec.File{SrcHandle: req.SrcHandle, FileHandle: req.FileHandle, Offset: int32(len(chunk))}
+	d.reply(f, codec.MsgRetFileRead, append(hdr.AppendTo(nil), chunk...))
+}

--- a/internal/snell-rollcall/consumer/devicehandler_test.go
+++ b/internal/snell-rollcall/consumer/devicehandler_test.go
@@ -280,9 +280,13 @@ func (d *device) deviceMap(f codec.Frame) {
 		count = 0
 	}
 	odd := d.oddListItem
+	bad := d.badMapEntry
 	d.block(f, codec.MsgGetLocDevMap, count, func(i int) (codec.PacketType, []byte) {
 		if i == odd {
 			return codec.MsgAck, nil
+		}
+		if bad {
+			return codec.MsgRetDevInfo, []byte{0x01}
 		}
 		info := codec.DeviceInfo{
 			ProtocolVersion: codec.ProtocolVersion,
@@ -621,10 +625,14 @@ func (d *device) fileDir(f codec.Frame) {
 		sizes[name] = len(body)
 	}
 	garble := d.garbleDirEntry
+	odd := d.oddDirItem
 	d.mu.Unlock()
 	sort.Strings(names)
 
 	d.block(f, codec.MsgFileDir, len(names), func(i int) (codec.PacketType, []byte) {
+		if i == odd {
+			return codec.MsgAck, nil
+		}
 		if garble {
 			return codec.MsgRetFileDir, []byte{0x01}
 		}
@@ -650,7 +658,21 @@ func (d *device) fileRead(f codec.Frame) {
 
 	d.mu.Lock()
 	body, ok := d.openFiles[req.FileHandle]
+	failAfter := d.failReadAfter
+	short := d.shortReadCount
+	endless := d.endlessFile
+	if failAfter >= 0 {
+		d.failReadAfter--
+	}
 	d.mu.Unlock()
+
+	if failAfter == 0 {
+		// The device gives up part way through, which is what a card being
+		// pulled during a template download looks like.
+		fail := codec.File{SrcHandle: req.SrcHandle, Extra: codec.FileErrAccess}
+		d.reply(f, codec.MsgRetFileRead, fail.AppendTo(nil))
+		return
+	}
 
 	if !ok {
 		fail := codec.File{SrcHandle: req.SrcHandle, Extra: codec.FileErrInvalid}
@@ -677,8 +699,24 @@ func (d *device) fileRead(f codec.Frame) {
 	}
 	chunk := body[off:end]
 
+	if endless {
+		// Never reaches the end, so a client with no ceiling would read for
+		// ever.
+		chunk = body
+		if len(chunk) == 0 {
+			chunk = []byte{0}
+		}
+	}
+
 	// In the reply the offset is how many bytes were read and the extra is
 	// the error, which is the opposite of the request.
-	hdr := codec.File{SrcHandle: req.SrcHandle, FileHandle: req.FileHandle, Offset: int32(len(chunk))}
+	count = len(chunk)
+	if short && count > 1 {
+		// The reply understates what it carries. The count is what a client
+		// must believe: reading past it would take bytes the device did not
+		// mean to send.
+		count--
+	}
+	hdr := codec.File{SrcHandle: req.SrcHandle, FileHandle: req.FileHandle, Offset: int32(count)}
 	d.reply(f, codec.MsgRetFileRead, append(hdr.AppendTo(nil), chunk...))
 }

--- a/internal/snell-rollcall/consumer/discover.go
+++ b/internal/snell-rollcall/consumer/discover.go
@@ -1,0 +1,189 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// GetDeviceInfo returns what the gateway said about itself during the
+// handshake, plus how many ports it has.
+//
+// The port count is what the neutral model calls the slot count, and it costs
+// a device-list walk to learn, so it is counted once and kept.
+func (p *Plugin) GetDeviceInfo(ctx context.Context) (consumer.DeviceInfo, error) {
+	l, err := p.conn()
+	if err != nil {
+		return consumer.DeviceInfo{}, err
+	}
+
+	slots, err := p.slotCount(ctx, l)
+	if err != nil {
+		return consumer.DeviceInfo{}, err
+	}
+
+	return consumer.DeviceInfo{
+		IP:              p.addr,
+		Port:            p.port,
+		NumSlots:        slots,
+		ProtocolVersion: int(l.gateway.ProtocolVersion),
+	}, nil
+}
+
+// Devices returns every unit the gateway knows about.
+//
+// A RollCall gateway keeps a map of what it has heard announce itself, and
+// walking that map is discovery. The map ages entries out after sixty seconds
+// without an announcement, so a unit missing from it is a unit that has gone
+// quiet rather than one that never existed.
+func (p *Plugin) Devices(ctx context.Context) ([]codec.DeviceInfo, error) {
+	l, err := p.conn()
+	if err != nil {
+		return nil, err
+	}
+
+	// The map is fetched outside any session: it is a property of the
+	// gateway, and asking for it opens a transient session the gateway
+	// closes itself when the walk ends.
+	s, err := p.session(ctx, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []codec.DeviceInfo
+	err = session.Walk(ctx, s, codec.MsgGetLocDevMap, nil, func(_ int, f codec.Frame) error {
+		if f.Type != codec.MsgRetDevInfo {
+			return nil
+		}
+		info, err := codec.DecodeDeviceInfo(f.Payload)
+		if err != nil {
+			return err
+		}
+		out = append(out, info)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: device map: %w", err)
+	}
+
+	if len(out) == 0 {
+		// A gateway with no map still has itself.
+		out = append(out, l.gateway)
+	}
+	return out, nil
+}
+
+// Ports returns the ports of one unit, which are its cards.
+func (p *Plugin) Ports(ctx context.Context, unit uint8) ([]codec.DeviceInfo, error) {
+	s, err := p.session(ctx, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []codec.DeviceInfo
+	err = session.Walk(ctx, s, codec.MsgGetDevList, []byte{unit, 0},
+		func(_ int, f codec.Frame) error {
+			if f.Type != codec.MsgRetDevInfo {
+				return nil
+			}
+			info, err := codec.DecodeDeviceInfo(f.Payload)
+			if err != nil {
+				return err
+			}
+			out = append(out, info)
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: port list for unit %02X: %w", unit, err)
+	}
+	return out, nil
+}
+
+// slotCount returns how many ports the gateway has.
+//
+// It takes the link rather than looking it up again: its only caller has just
+// done that, and checking twice would leave a branch that cannot be reached
+// except by a disconnection landing in the gap between them.
+func (p *Plugin) slotCount(ctx context.Context, l *link) (int, error) {
+	ports, err := p.Ports(ctx, l.sess.RemoteAddress().Unit)
+	if err != nil {
+		return 0, err
+	}
+	return len(ports), nil
+}
+
+// GetSlotInfo returns the identity and state of one port.
+//
+// A port's identity is the card in it: its type id names the product, and its
+// version plus that id is what identifies a device model, which is why both
+// are reported rather than only the name.
+func (p *Plugin) GetSlotInfo(ctx context.Context, slot int) (consumer.SlotInfo, error) {
+	if slot < 0 || slot > 0xFF {
+		return consumer.SlotInfo{}, fmt.Errorf("rollcall: slot %d is outside the port range", slot)
+	}
+
+	s, err := p.session(ctx, uint8(slot))
+	if err != nil {
+		return consumer.SlotInfo{}, err
+	}
+
+	idReply, err := s.Do(ctx, codec.MsgGetID, nil)
+	if err != nil {
+		return consumer.SlotInfo{}, err
+	}
+	id, err := codec.DecodeID(idReply.Payload)
+	if err != nil {
+		return consumer.SlotInfo{}, fmt.Errorf("rollcall: slot %d identity: %w", slot, err)
+	}
+
+	statReply, err := s.Do(ctx, codec.MsgGetStat, nil)
+	if err != nil {
+		return consumer.SlotInfo{}, err
+	}
+	st, err := codec.DecodeUnitStatus(statReply.Payload)
+	if err != nil {
+		return consumer.SlotInfo{}, fmt.Errorf("rollcall: slot %d status: %w", slot, err)
+	}
+
+	info := consumer.SlotInfo{
+		Slot:     slot,
+		State:    slotState(st.Status),
+		IsOnline: st.Status.Has(codec.StatusPresent),
+		LiveAt:   p.clk.Now(),
+		Identity: map[string]string{
+			"name":     id.Name,
+			"type":     codec.UnitTypeName(id.TypeID),
+			"type_id":  fmt.Sprint(id.TypeID),
+			"version":  id.Version.String(),
+			"services": id.Services.String(),
+		},
+	}
+	if ty, ok := codec.LookupUnitType(id.TypeID); ok {
+		info.Identity["product"] = ty.Enum
+		info.Identity["category"] = ty.Category.String()
+	}
+	return info, nil
+}
+
+// slotState maps a unit's status flags onto the neutral slot state.
+//
+// A unit reports whether it is present and whether it is under local control.
+// It has no notion of a card that is booting or removed, so those states are
+// never produced rather than guessed at: a port that is not present is empty,
+// and that is all the protocol says.
+func slotState(s codec.Status) consumer.SlotState {
+	switch {
+	case !s.Has(codec.StatusPresent):
+		return consumer.SlotStateNoCard
+	case s.Has(codec.StatusLocal):
+		// Present, but taking orders from its own front panel rather than
+		// from us. The neutral model has no word for that, and "present" is
+		// the honest one: it is there and it is working.
+		return consumer.SlotStatePresent
+	default:
+		return consumer.SlotStatePresent
+	}
+}

--- a/internal/snell-rollcall/consumer/errors_test.go
+++ b/internal/snell-rollcall/consumer/errors_test.go
@@ -1,0 +1,675 @@
+package rollcall
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// A device that says no is not a broken device. Refusing a command is how the
+// protocol says "not at your user level", "not on this card" or "not while I
+// am busy", and every one of those has to reach the caller as an error rather
+// than as a zero value.
+
+// TestDeviceRefusals covers a device answering each request with a refusal.
+func TestDeviceRefusals(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  codec.PacketType
+		// only restricts a case to one generation, because the two use
+		// different message types and injecting a fault into one a session
+		// never sends proves nothing. Empty means both.
+		only string
+		call func(*Plugin) error
+	}{
+		{"identity", codec.MsgGetID, "", func(p *Plugin) error {
+			_, err := p.GetSlotInfo(context.Background(), 1)
+			return err
+		}},
+		{"status", codec.MsgGetStat, "", func(p *Plugin) error {
+			_, err := p.GetSlotInfo(context.Background(), 1)
+			return err
+		}},
+		{"menu count", codec.MsgGetMenuCount, "32", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"menu item", codec.MsgGetMenuItem, "32", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"menu block, 16-bit", codec.MsgGetFunc, "16", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"value, 16-bit", codec.MsgGetFStat, "16", func(p *Plugin) error {
+			_, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, ID: 0x0113})
+			return err
+		}},
+		{"write, 16-bit", codec.MsgSetParam, "16", func(p *Plugin) error {
+			_, err := p.SetValue(context.Background(),
+				consumer.ValueRequest{Slot: 1, ID: 0x0113},
+				consumer.Value{Kind: consumer.KindInt, Int: 1})
+			return err
+		}},
+		{"default, 16-bit", codec.MsgSetParam, "16", func(p *Plugin) error {
+			_, err := p.SetDefault(context.Background(), consumer.ValueRequest{Slot: 1, ID: 0x0113})
+			return err
+		}},
+		{"default", codec.MsgSetValue, "32", func(p *Plugin) error {
+			_, err := p.SetDefault(context.Background(), consumer.ValueRequest{Slot: 1, ID: 0x0113})
+			return err
+		}},
+		{"port list", codec.MsgGetDevList, "", func(p *Plugin) error {
+			_, err := p.GetDeviceInfo(context.Background())
+			return err
+		}},
+		{"device map", codec.MsgGetLocDevMap, "", func(p *Plugin) error {
+			_, err := p.Devices(context.Background())
+			return err
+		}},
+		{"display", codec.MsgGetDispData, "", func(p *Plugin) error {
+			_, err := p.Display(context.Background(), 1)
+			return err
+		}},
+		{"file open", codec.MsgFileOpen, "", func(p *Plugin) error {
+			_, err := p.ReadFile(context.Background(), 0, "A.BIN")
+			return err
+		}},
+		{"directory", codec.MsgFileDir, "", func(p *Plugin) error {
+			_, err := p.ListDir(context.Background(), 0, "/")
+			return err
+		}},
+	}
+	// Both generations, because the 16-bit and 32-bit paths are separate code
+	// and a failure handled in one says nothing about the other.
+	for _, gen := range generations() {
+		t.Run(gen.name, func(t *testing.T) {
+			for _, tc := range tests {
+				if tc.only != "" && tc.only != gen.name[:2] {
+					continue
+				}
+				t.Run(tc.name, func(t *testing.T) {
+					h := newHarness(t, func(d *device) {
+						gen.setup(d)
+						d.setMenu(1, testMenu())
+						d.setFile("A.BIN", []byte("x"))
+						d.refuse[tc.typ] = true
+					})
+					if err := tc.call(h.plugin); err == nil {
+						t.Errorf("a refused %s should reach the caller as an error", tc.typ)
+					}
+				})
+			}
+		})
+	}
+}
+
+// generations runs a test over both wire generations. A connector that serves
+// only the one it was tested on is half a connector, and the read, write and
+// menu paths are separate code in each.
+func generations() []struct {
+	name  string
+	long  bool
+	setup func(*device)
+} {
+	return []struct {
+		name  string
+		long  bool
+		setup func(*device)
+	}{
+		{"32-bit", true, func(*device) {}},
+		{"16-bit", false, func(d *device) { d.services &^= codec.SvcLongStr }},
+	}
+}
+
+// TestDeviceGarbledReplies covers a device answering with the right message
+// type and a payload too short to decode, which is what a firmware fault looks
+// like from outside. It must be an error rather than a zero value: a gain
+// silently read as zero is worse than a read that failed.
+func TestDeviceGarbledReplies(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  codec.PacketType
+		// only restricts a case to one generation, because the two use
+		// different message types and injecting a fault into one a session
+		// never sends proves nothing. Empty means both.
+		only string
+		call func(*Plugin) error
+	}{
+		{"identity", codec.MsgGetID, "", func(p *Plugin) error {
+			_, err := p.GetSlotInfo(context.Background(), 1)
+			return err
+		}},
+		{"status", codec.MsgGetStat, "", func(p *Plugin) error {
+			_, err := p.GetSlotInfo(context.Background(), 1)
+			return err
+		}},
+		{"menu count", codec.MsgGetMenuCount, "32", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"menu item", codec.MsgGetMenuItem, "32", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"value", codec.MsgGetValue, "32", func(p *Plugin) error {
+			_, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, ID: 0x0113})
+			return err
+		}},
+		{"value, 16-bit", codec.MsgGetFStat, "16", func(p *Plugin) error {
+			_, err := p.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, ID: 0x0113})
+			return err
+		}},
+		{"write reply", codec.MsgSetValue, "32", func(p *Plugin) error {
+			_, err := p.SetValue(context.Background(),
+				consumer.ValueRequest{Slot: 1, ID: 0x0113},
+				consumer.Value{Kind: consumer.KindInt, Int: 1})
+			return err
+		}},
+		{"write reply, 16-bit", codec.MsgSetParam, "16", func(p *Plugin) error {
+			_, err := p.SetValue(context.Background(),
+				consumer.ValueRequest{Slot: 1, ID: 0x0113},
+				consumer.Value{Kind: consumer.KindInt, Int: 1})
+			return err
+		}},
+		{"menu block, 16-bit", codec.MsgGetFunc, "16", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"menu line, 16-bit", codec.MsgGetNextPkt, "16", func(p *Plugin) error {
+			_, err := p.Walk(context.Background(), 1)
+			return err
+		}},
+		{"port list", codec.MsgGetDevList, "", func(p *Plugin) error {
+			_, err := p.Ports(context.Background(), gatewayAddr.Unit)
+			return err
+		}},
+		{"display", codec.MsgGetDispData, "", func(p *Plugin) error {
+			_, err := p.Display(context.Background(), 1)
+			return err
+		}},
+		{"file open", codec.MsgFileOpen, "", func(p *Plugin) error {
+			_, err := p.ReadFile(context.Background(), 0, "A.BIN")
+			return err
+		}},
+		{"file read", codec.MsgFileRead, "", func(p *Plugin) error {
+			_, err := p.ReadFile(context.Background(), 0, "A.BIN")
+			return err
+		}},
+		{"directory block", codec.MsgFileDir, "", func(p *Plugin) error {
+			_, err := p.ListDir(context.Background(), 0, "/")
+			return err
+		}},
+	}
+	for _, gen := range generations() {
+		t.Run(gen.name, func(t *testing.T) {
+			for _, tc := range tests {
+				if tc.only != "" && tc.only != gen.name[:2] {
+					continue
+				}
+				t.Run(tc.name, func(t *testing.T) {
+					h := newHarness(t, func(d *device) {
+						gen.setup(d)
+						d.setMenu(1, testMenu())
+						d.setFile("A.BIN", []byte("x"))
+						d.garble[tc.typ] = true
+					})
+					if err := tc.call(h.plugin); err == nil {
+						t.Errorf("a garbled %s reply should be an error, not a zero value", tc.typ)
+					}
+				})
+			}
+		})
+	}
+
+	// A garbled entry inside a directory listing needs its own switch: every
+	// item of a multi-packet transfer answers the same request type, so the
+	// type alone cannot say which transfer to spoil.
+	t.Run("directory entry", func(t *testing.T) {
+		h := newHarness(t, func(d *device) {
+			d.setFile("A.BIN", []byte("x"))
+			d.garbleDirEntry = true
+		})
+		if _, err := h.plugin.ListDir(context.Background(), 0, "/"); err == nil {
+			t.Error("a garbled directory entry should be an error")
+		}
+	})
+}
+
+// TestSessionRefused covers a device that will not open a session at all,
+// which is what a unit with none left does.
+func TestSessionRefused(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgCall] = true })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err == nil {
+		t.Error("a refused session should fail the walk")
+	}
+	if _, err := h.plugin.GetSlotInfo(ctx, 1); err == nil {
+		t.Error("a refused session should fail the slot query")
+	}
+	if _, err := h.plugin.Uses32Bit(ctx, 1); err == nil {
+		t.Error("a refused session should fail the generation query")
+	}
+	if _, err := h.plugin.ReadFile(ctx, 0, "A.BIN"); err == nil {
+		t.Error("a refused session should fail the file read")
+	}
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1}, func(consumer.Event) {}); err == nil {
+		t.Error("a refused session should fail the subscription")
+	}
+	if _, err := h.plugin.ListDir(ctx, 0, "/"); err == nil {
+		t.Error("a refused session should fail the directory listing")
+	}
+}
+
+// TestListDir covers a directory listing, which is how a client finds what a
+// device has before asking for it.
+func TestListDir(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("TEMPLATE.ZIP", make([]byte, 4096))
+		d.setFile("NAMES.DAT", make([]byte, 128))
+	})
+
+	entries, err := h.plugin.ListDir(context.Background(), 0, "/")
+	if err != nil {
+		t.Fatalf("ListDir: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("listed %d entries, want 2", len(entries))
+	}
+	byName := map[string]codec.DirEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+	if got := byName["TEMPLATE.ZIP"].Info.Length; got != 4096 {
+		t.Errorf("TEMPLATE.ZIP is %d bytes, want 4096", got)
+	}
+	if _, ok := byName["NAMES.DAT"]; !ok {
+		t.Error("NAMES.DAT is missing from the listing")
+	}
+}
+
+// TestReadFile_SessionIsReused covers the file session being opened once. A
+// unit has few sessions and running out is what stops it answering anybody, so
+// a second read must not cost another.
+func TestReadFile_SessionIsReused(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", []byte("first"))
+		d.setFile("B.BIN", []byte("second"))
+	})
+	ctx := context.Background()
+
+	if _, err := h.plugin.ReadFile(ctx, 0, "A.BIN"); err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	h.device.mu.Lock()
+	after1 := len(h.device.sessions)
+	h.device.mu.Unlock()
+
+	if _, err := h.plugin.ReadFile(ctx, 0, "B.BIN"); err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	h.device.mu.Lock()
+	after2 := len(h.device.sessions)
+	h.device.mu.Unlock()
+
+	if after2 != after1 {
+		t.Errorf("a second read opened another session: %d then %d", after1, after2)
+	}
+}
+
+// TestOverlongPath covers a caller naming a path longer than the service
+// accepts. It fails locally rather than sending something a device will reject.
+func TestOverlongPath(t *testing.T) {
+	h := newHarness(t, nil)
+	long := strings.Repeat("x", codec.MaxFileName+10)
+	ctx := context.Background()
+
+	if _, err := h.plugin.ReadFile(ctx, 0, long); !errors.Is(err, codec.ErrStringTooLong) {
+		t.Errorf("read err = %v, want ErrStringTooLong", err)
+	}
+	if _, err := h.plugin.ListDir(ctx, 0, long); !errors.Is(err, codec.ErrStringTooLong) {
+		t.Errorf("list err = %v, want ErrStringTooLong", err)
+	}
+	var sink discardWriter
+	if _, err := h.plugin.ReadFileTo(ctx, 0, long, sink); !errors.Is(err, codec.ErrStringTooLong) {
+		t.Errorf("stream err = %v, want ErrStringTooLong", err)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestCommandTooWideForTheSession covers a router command on a 16-bit session.
+// Its number cannot be expressed at all in that generation, so the read is
+// refused rather than truncated into a different command.
+func TestCommandTooWideForTheSession(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services &^= codec.SvcLongStr
+		d.setMenu(1, testMenu())
+	})
+	ctx := context.Background()
+
+	req := consumer.ValueRequest{Slot: 1, ID: 0x0010_4EEF}
+
+	_, err := h.plugin.GetValue(ctx, req)
+	if err == nil {
+		t.Fatal("a 32-bit command must not be readable on a 16-bit session")
+	}
+	if !strings.Contains(err.Error(), "32-bit") {
+		t.Errorf("err = %v, want it to name the generation", err)
+	}
+
+	_, err = h.plugin.SetValue(ctx, req, consumer.Value{Kind: consumer.KindInt, Int: 1})
+	if err == nil {
+		t.Fatal("a 32-bit command must not be writable on a 16-bit session")
+	}
+}
+
+// TestEncodeValueKinds covers turning a neutral value into a write.
+func TestEncodeValueKinds(t *testing.T) {
+	p := New(testDeps())
+	line := &menuLine{Command: 1, Style: codec.StyleNumber, DivScale: 10}
+
+	tests := []struct {
+		name string
+		in   consumer.Value
+		mode codec.Mode
+		num  int32
+		text string
+		fail bool
+	}{
+		{"bool true", consumer.Value{Kind: consumer.KindBool, Bool: true}, codec.ModeValue, 1, "", false},
+		{"bool false", consumer.Value{Kind: consumer.KindBool}, codec.ModeValue, 0, "", false},
+		{"int", consumer.Value{Kind: consumer.KindInt, Int: -42}, codec.ModeValue, -42, "", false},
+		{"uint", consumer.Value{Kind: consumer.KindUint, Uint: 42}, codec.ModeValue, 42, "", false},
+		// A float is in the displayed units, so it is scaled back into wire
+		// units by the line's own divisor.
+		{"float", consumer.Value{Kind: consumer.KindFloat, Float: -6.0}, codec.ModeValue, -60, "", false},
+		{"string", consumer.Value{Kind: consumer.KindString, Str: "hi"}, codec.ModeString, 0, "hi", false},
+		{"bare number", consumer.Value{Int: 7}, codec.ModeValue, 7, "", false},
+		{"bare string", consumer.Value{Str: "hi"}, codec.ModeString, 0, "hi", false},
+		{"raw", consumer.Value{Kind: consumer.KindRaw, Raw: []byte{1}}, 0, 0, "", true},
+		{"frame", consumer.Value{Kind: consumer.KindFrame}, 0, 0, "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, num, text, err := p.encodeValue(line, tc.in)
+			if tc.fail {
+				if err == nil {
+					t.Errorf("writing a %s should be refused", tc.in.Kind)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("encodeValue: %v", err)
+			}
+			if mode != tc.mode || num != tc.num || text != tc.text {
+				t.Errorf("= %s %d %q, want %s %d %q", mode, num, text, tc.mode, tc.num, tc.text)
+			}
+		})
+	}
+}
+
+// TestValueFromRawData covers a command whose value is opaque bytes, which is
+// what the router command set carries its parameters in.
+func TestValueFromRawData(t *testing.T) {
+	p := New(testDeps())
+	line := &menuLine{Command: 1, Style: codec.StyleData}
+
+	v := p.valueFrom(line, codec.ModeData, 3, "", []byte{1, 2, 3})
+	if v.Kind != consumer.KindRaw {
+		t.Errorf("kind = %s, want raw", v.Kind)
+	}
+	if len(v.Raw) != 3 {
+		t.Errorf("raw = %x, want three bytes", v.Raw)
+	}
+
+	// The bytes are copied rather than aliased, because the frame they came
+	// from is reused by the next read.
+	v.Raw[0] = 9
+	again := p.valueFrom(line, codec.ModeData, 3, "", []byte{1, 2, 3})
+	if again.Raw[0] != 1 {
+		t.Error("the raw value aliases the frame it was decoded from")
+	}
+}
+
+// TestValueFromStringOnly covers a reply that carries only a string on a line
+// the menu called numeric, which happens on a device whose menu and values
+// disagree.
+func TestValueFromStringOnly(t *testing.T) {
+	p := New(testDeps())
+	line := &menuLine{Command: 1, Style: codec.StyleNumber}
+
+	v := p.valueFrom(line, codec.ModeString, 0, "text", nil)
+	if v.Kind != consumer.KindString || v.Str != "text" {
+		t.Errorf("= %s %q, want the string the device sent", v.Kind, v.Str)
+	}
+}
+
+// TestDispatchIgnoresUnknownPushes covers a device pushing something the
+// connector has no use for. It must not crash and must not be delivered as a
+// value.
+func TestDispatchIgnoresUnknownPushes(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// A message type that carries no value, and a value push whose payload
+	// will not decode. Neither should reach a listener.
+	h.device.push(1, codec.MsgTime, nil)
+	h.device.push(1, codec.MsgRetValue, []byte{0x01})
+	h.device.push(1, codec.MsgRetFStat, []byte{0x01})
+	h.device.push(1, codec.MsgDispData, []byte{0x01})
+
+	// A good one afterwards proves the pump survived all four.
+	good, err := codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 7}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetValue, good)
+
+	select {
+	case ev := <-events:
+		if ev.Value.Int != 7 {
+			t.Errorf("first delivered event carried %d, want 7", ev.Value.Int)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the pump stopped on an undecodable push")
+	}
+}
+
+// TestDisplayPush covers a status line arriving on the back channel, and the
+// line numbers the display service does not define.
+func TestDisplayPush(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// An error line, which is a priority rather than a position.
+	errLine, err := codec.Disp{Line: codec.DisplayLineError, Text: "no input"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgDispData, errLine)
+
+	select {
+	case ev := <-events:
+		if ev.Label != "error" {
+			t.Errorf("label = %q, want the priority named", ev.Label)
+		}
+		if ev.Value.Str != "no input" {
+			t.Errorf("text = %q", ev.Value.Str)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the display push was not delivered")
+	}
+
+	// A line outside the four the service defines is kept under its own
+	// number and reported, because the device is using the service in a way
+	// the specification does not describe.
+	odd, err := codec.Disp{Line: 42, Text: "extra"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgDispData, odd)
+
+	select {
+	case ev := <-events:
+		if ev.ID != 42 {
+			t.Errorf("id = %d, want the line number it arrived under", ev.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("an out-of-range display line was dropped")
+	}
+	if !hasEvent(h.plugin, EventDisplayLineOutOfRange) {
+		t.Error("an out-of-range display line was not reported")
+	}
+}
+
+// TestStyleChangeInvalidatesTheWalk covers a line becoming hidden or disabled.
+// The cached menu is then wrong about what a caller may write, so it is
+// dropped rather than used.
+func TestStyleChangeInvalidatesTheWalk(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(consumer.Event) {}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	change := codec.FuncStyle{MenuIndex: 1, Style: codec.StyleNumber | codec.StyleDisabled}
+	h.device.push(1, codec.MsgFuncStyleChg, change.AppendTo(nil))
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.plugin.mu.RLock()
+		cached := h.plugin.trees[1] != nil
+		h.plugin.mu.RUnlock()
+		if !cached {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a style change did not invalidate the cached walk")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestUnsubscribeUnknown covers removing a subscription that was never made,
+// and one for an object that cannot be resolved.
+func TestUnsubscribeUnknown(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	if err := h.plugin.Unsubscribe(consumer.ValueRequest{Slot: 1}); err != nil {
+		t.Errorf("unsubscribing something never subscribed: %v", err)
+	}
+	if err := h.plugin.Unsubscribe(consumer.ValueRequest{Slot: 1, Label: "nothing"}); err == nil {
+		t.Error("unsubscribing an unresolvable object should say so")
+	}
+}
+
+// TestSubscribeWithoutAMenu covers a device with no menu service. Values can
+// still be pushed and delivered; they simply arrive without labels.
+func TestSubscribeWithoutAMenu(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetMenuCount] = true })
+
+	events := make(chan consumer.Event, 4)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	value, err := codec.Value{Command: 99, Mode: codec.ModeValue, Val: 1}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetValue, value)
+
+	select {
+	case ev := <-events:
+		if ev.ID != 99 {
+			t.Errorf("id = %d", ev.ID)
+		}
+		if ev.Label != "" {
+			t.Errorf("label = %q, want none without a menu", ev.Label)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a push without a menu was not delivered")
+	}
+
+	// A command the menu does not list is reported, because the device knows
+	// its own command set better than a cached walk does.
+	if !hasEvent(h.plugin, EventUnsolicitedCommand) {
+		t.Error("an unlisted command was not reported")
+	}
+}
+
+// TestDuplicateCommandsAreReported covers two menu lines claiming the same
+// command number. Both are kept, because a write to either reaches the same
+// place, and the first keeps the label.
+func TestDuplicateCommandsAreReported(t *testing.T) {
+	menu := []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleNumber, Command: 5, Text: "First"},
+		{MenuIndex: 1, Style: codec.StyleNumber, Command: 5, Text: "Second"},
+	}
+	h := newHarness(t, func(d *device) { d.setMenu(1, menu) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Errorf("walked %d objects, want both kept", len(objects))
+	}
+	if !hasEvent(h.plugin, EventDuplicateCommand) {
+		t.Error("the duplicate command was not reported")
+	}
+}
+
+// TestMenuSpanOverrunIsClamped covers a container claiming a subtree longer
+// than the menu that contains it. The tree is still built, from what is
+// actually there, and the claim is reported.
+func TestMenuSpanOverrunIsClamped(t *testing.T) {
+	menu := []codec.MenuItem{
+		{MenuIndex: 0, Style: codec.StyleList, Step: 99, Text: "Root"},
+		{MenuIndex: 1, Style: codec.StyleNumber, Command: 1, Text: "Only"},
+	}
+	h := newHarness(t, func(d *device) { d.setMenu(1, menu) })
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Fatalf("walked %d objects, want 2", len(objects))
+	}
+	if !hasEvent(h.plugin, EventMenuSpanOverruns) {
+		t.Error("the overrunning span was not reported")
+	}
+	// The line that was there is still nested under the container.
+	for _, o := range objects {
+		if o.Label == "Only" && len(o.Path) != 2 {
+			t.Errorf("Only is at %v, want it under Root", o.Path)
+		}
+	}
+}

--- a/internal/snell-rollcall/consumer/file.go
+++ b/internal/snell-rollcall/consumer/file.go
@@ -1,0 +1,243 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// The file service is how two things in this protocol actually work.
+//
+// A router publishes every source and destination name in a file, named by a
+// filename and a checksum, because sending sixty-five thousand names as
+// individual commands would take longer than anyone will wait. And the vendor's
+// Control Panel will not render a device at all without reading TEMPLATE.ZIP
+// from it, which the menu service cannot supply.
+//
+// So this is not an optional extra: without it a router has no labels and a
+// producer has no user interface.
+
+// defaultReadChunk is how much to ask for when the peer does not say.
+//
+// A frame carries 420 payload bytes and a read reply spends ten of them on its
+// own structure, so this is what fits without fragmenting. A peer states its
+// own maximum in the reply to an open, and that figure wins when it is
+// smaller: the server clamps a larger request rather than refusing it, so
+// asking for more than it allows simply wastes the excess on every block.
+const defaultReadChunk = codec.MaxPayload - codec.FileSize
+
+// ReadFile reads a whole file from a slot.
+//
+// The file is opened in binary mode, always. Text mode makes the peer translate
+// line endings, which corrupts an archive or a names file, and it does so
+// silently: the read succeeds and the bytes are wrong.
+func (p *Plugin) ReadFile(ctx context.Context, slot int, path string) ([]byte, error) {
+	s, err := p.fileSession(ctx, uint8(slot))
+	if err != nil {
+		return nil, err
+	}
+
+	handle, chunk, err := p.openFile(ctx, s, path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cerr := p.closeFile(context.WithoutCancel(ctx), s, handle); cerr != nil {
+			p.log.Debug("rollcall: closing a file failed",
+				"path", path, "slot", slot, "err", cerr)
+		}
+	}()
+
+	var out []byte
+	for {
+		chunk, err := p.readAt(ctx, s, handle, int32(len(out)), chunk)
+		if err != nil {
+			return nil, fmt.Errorf("rollcall: read %q at %d: %w", path, len(out), err)
+		}
+		if len(chunk) == 0 {
+			return out, nil
+		}
+		out = append(out, chunk...)
+
+		if len(out) > codec.MaxPayload*100000 {
+			return nil, fmt.Errorf("rollcall: %q is longer than any file this protocol carries", path)
+		}
+	}
+}
+
+// openFile opens a path and returns the server's handle and the block size it
+// wants reads to use.
+func (p *Plugin) openFile(ctx context.Context, s *session.Session, path string) (int16, int, error) {
+	payload, err := codec.AppendFileOpen(nil, 1, codec.OpenReadOnly|codec.OpenBinary, path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgFileOpen, payload)
+	if err != nil {
+		return 0, 0, fmt.Errorf("rollcall: open %q: %w", path, err)
+	}
+	f, err := codec.DecodeFile(reply.Payload)
+	if err != nil {
+		return 0, 0, fmt.Errorf("rollcall: open %q: %w", path, err)
+	}
+	if err := f.Err(); err != nil {
+		return 0, 0, fmt.Errorf("rollcall: open %q: %w", path, err)
+	}
+
+	// The reply overwrites both numeric fields: the offset now carries the
+	// peer's maximum block size and the extra carries the error. Honour the
+	// size it gave, and fall back to what a frame holds when it gave none.
+	chunk := f.BlockSize()
+	if chunk <= 0 || chunk > defaultReadChunk {
+		chunk = defaultReadChunk
+	}
+	return f.FileHandle, chunk, nil
+}
+
+// readAt reads one block from an offset, and returns an empty slice at the end
+// of the file.
+func (p *Plugin) readAt(ctx context.Context, s *session.Session, handle int16, off int32, count int) ([]byte, error) {
+	// Offset says where to read from and Extra says how many bytes to read.
+	// Both change meaning in the reply, where they become the number read and
+	// the error.
+	req := codec.FileReadRequest(1, handle, off, count)
+
+	reply, err := s.Do(ctx, codec.MsgFileRead, req.AppendTo(nil))
+	if err != nil {
+		return nil, err
+	}
+	f, err := codec.DecodeFile(reply.Payload)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Err(); err != nil {
+		return nil, err
+	}
+
+	// What follows the structure is the data. The offset field on a reply
+	// says how much was read, but the payload is what actually arrived, so
+	// the payload wins: a peer that disagrees with itself must not make us
+	// read past what it sent.
+	data := reply.Payload[codec.FileSize:]
+	if n := int(f.Offset); n >= 0 && n < len(data) {
+		data = data[:n]
+	}
+	return data, nil
+}
+
+func (p *Plugin) closeFile(ctx context.Context, s *session.Session, handle int16) error {
+	req := codec.File{SrcHandle: 1, FileHandle: handle}
+	_, err := s.Do(ctx, codec.MsgFileClose, req.AppendTo(nil))
+	return err
+}
+
+// ListDir lists a directory on a slot.
+func (p *Plugin) ListDir(ctx context.Context, slot int, path string) ([]codec.DirEntry, error) {
+	s, err := p.fileSession(ctx, uint8(slot))
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := codec.AppendFilePath(nil, 1, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []codec.DirEntry
+	err = session.Walk(ctx, s, codec.MsgFileDir, payload, func(_ int, f codec.Frame) error {
+		if f.Type != codec.MsgRetFileDir {
+			return nil
+		}
+		entry, err := codec.DecodeDirEntry(f.Payload)
+		if err != nil {
+			return err
+		}
+		out = append(out, entry)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: list %q: %w", path, err)
+	}
+	return out, nil
+}
+
+// fileSession returns a session that has the file service.
+//
+// It is a separate session from the control one because the services are
+// negotiated together and all-or-nothing: asking for the file service on the
+// control session would mean a unit without one could not be controlled at
+// all.
+func (p *Plugin) fileSession(ctx context.Context, port uint8) (*session.Session, error) {
+	l, err := p.conn()
+	if err != nil {
+		return nil, err
+	}
+
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil, fmt.Errorf("rollcall: link closed")
+	}
+	if s, ok := l.fileSessions[port]; ok {
+		l.mu.Unlock()
+		return s, nil
+	}
+	l.mu.Unlock()
+
+	peer := l.sess.RemoteAddress()
+	peer.Port = port
+
+	s, err := session.Call(ctx, l.sess, peer, codec.SvcFile,
+		codec.LevelSupervisor, p.identity())
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: file service on port %02X: %w", port, err)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		_ = s.Close()
+		return nil, fmt.Errorf("rollcall: link closed")
+	}
+	if existing, ok := l.fileSessions[port]; ok {
+		go func() { _ = s.Close() }()
+		return existing, nil
+	}
+	l.fileSessions[port] = s
+	return s, nil
+}
+
+// ReadFileTo streams a file into a writer, for callers that would rather not
+// hold a whole archive in memory.
+func (p *Plugin) ReadFileTo(ctx context.Context, slot int, path string, w io.Writer) (int64, error) {
+	s, err := p.fileSession(ctx, uint8(slot))
+	if err != nil {
+		return 0, err
+	}
+
+	handle, size, err := p.openFile(ctx, s, path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = p.closeFile(context.WithoutCancel(ctx), s, handle) }()
+
+	var total int64
+	for {
+		chunk, err := p.readAt(ctx, s, handle, int32(total), size)
+		if err != nil {
+			return total, fmt.Errorf("rollcall: read %q at %d: %w", path, total, err)
+		}
+		if len(chunk) == 0 {
+			return total, nil
+		}
+		n, err := w.Write(chunk)
+		total += int64(n)
+		if err != nil {
+			return total, err
+		}
+	}
+}

--- a/internal/snell-rollcall/consumer/file.go
+++ b/internal/snell-rollcall/consumer/file.go
@@ -29,6 +29,21 @@ import (
 // asking for more than it allows simply wastes the excess on every block.
 const defaultReadChunk = codec.MaxPayload - codec.FileSize
 
+// DefaultMaxFileBytes bounds a single read.
+//
+// A device that keeps returning data never ends the loop, and a template
+// archive or a names file for the largest matrix is orders of magnitude below
+// this, so the ceiling only ever catches a peer that is misbehaving.
+const DefaultMaxFileBytes = 64 << 20
+
+// maxFileBytes is the ceiling in force, which a caller may lower.
+func (p *Plugin) maxFileBytes() int {
+	if p.fileCeiling > 0 {
+		return p.fileCeiling
+	}
+	return DefaultMaxFileBytes
+}
+
 // ReadFile reads a whole file from a slot.
 //
 // The file is opened in binary mode, always. Text mode makes the peer translate
@@ -62,8 +77,10 @@ func (p *Plugin) ReadFile(ctx context.Context, slot int, path string) ([]byte, e
 		}
 		out = append(out, chunk...)
 
-		if len(out) > codec.MaxPayload*100000 {
-			return nil, fmt.Errorf("rollcall: %q is longer than any file this protocol carries", path)
+		if len(out) > p.maxFileBytes() {
+			return nil, fmt.Errorf(
+				"rollcall: %q passed %d bytes without ending; the device is not stopping",
+				path, p.maxFileBytes())
 		}
 	}
 }

--- a/internal/snell-rollcall/consumer/mapping_test.go
+++ b/internal/snell-rollcall/consumer/mapping_test.go
@@ -1,0 +1,245 @@
+package rollcall
+
+import (
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestStyleKind covers every menu style, because the mapping is what makes a
+// RollCall menu legible to a caller that has never heard of RollCall, and a
+// style left out reads as an object of unknown type rather than failing.
+func TestStyleKind(t *testing.T) {
+	tests := []struct {
+		style codec.Style
+		want  consumer.ValueKind
+	}{
+		{codec.StyleTiled, consumer.KindUnknown},   // a node
+		{codec.StyleList, consumer.KindUnknown},    // a node
+		{codec.StylePartial, consumer.KindUnknown}, // a node
+		{codec.StyleDisplay, consumer.KindString},
+		{codec.StyleButton, consumer.KindInt},
+		{codec.StyleCheckbox, consumer.KindBool},
+		{codec.StyleNumber, consumer.KindInt},
+		{codec.StyleVGraph, consumer.KindInt},
+		{codec.StyleHGraph, consumer.KindInt},
+		{codec.StyleEditString, consumer.KindString},
+		{codec.StyleVLevel, consumer.KindInt},
+		{codec.StyleHLevel, consumer.KindInt},
+		{codec.StyleData, consumer.KindRaw},
+		{codec.StyleLink, consumer.KindString},
+		{0xE0, consumer.KindUnknown}, // a style the specification does not define
+	}
+	for _, tc := range tests {
+		if got := styleKind(tc.style); got != tc.want {
+			t.Errorf("%s maps to %s, want %s", tc.style, got, tc.want)
+		}
+		// Flags must not change the kind: a hidden number is still a number.
+		flagged := tc.style | codec.StyleHidden | codec.StyleCacheable
+		if got := styleKind(flagged); got != tc.want {
+			t.Errorf("%s with flags maps to %s, want %s", tc.style, got, tc.want)
+		}
+	}
+}
+
+// TestStyleAccess covers which lines a caller may write.
+//
+// Reporting a line as writable that a device will refuse invites a failure
+// the caller could have been spared, so a container, a display and anything
+// disabled are all read-only.
+func TestStyleAccess(t *testing.T) {
+	tests := []struct {
+		name  string
+		style codec.Style
+		write bool
+	}{
+		{"number", codec.StyleNumber, true},
+		{"checkbox", codec.StyleCheckbox, true},
+		{"editable string", codec.StyleEditString, true},
+		{"button", codec.StyleButton, true},
+		{"data", codec.StyleData, true},
+		{"tiled container", codec.StyleTiled, false},
+		{"list container", codec.StyleList, false},
+		{"partial container", codec.StylePartial, false},
+		{"display", codec.StyleDisplay, false},
+		{"disabled number", codec.StyleNumber | codec.StyleDisabled, false},
+		{"disabled checkbox", codec.StyleCheckbox | codec.StyleDisabled, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := styleAccess(tc.style)
+			if got&accessRead == 0 {
+				t.Error("every line is readable")
+			}
+			if (got&accessWrite != 0) != tc.write {
+				t.Errorf("writable = %v, want %v", got&accessWrite != 0, tc.write)
+			}
+			if got&accessSetDef != 0 {
+				t.Error("the default bit is carried on the value, not the style")
+			}
+		})
+	}
+}
+
+// TestSlotState covers the states a unit's status flags can produce.
+//
+// A unit reports whether it is present and whether it is under local control.
+// It has no notion of a card that is booting or has just been removed, so
+// those states are never produced rather than guessed at.
+func TestSlotState(t *testing.T) {
+	tests := []struct {
+		name   string
+		status codec.Status
+		want   consumer.SlotState
+	}{
+		{"empty", 0, consumer.SlotStateNoCard},
+		{"present", codec.StatusPresent, consumer.SlotStatePresent},
+		{"present and online", codec.StatusPresent | codec.StatusOnline, consumer.SlotStatePresent},
+		{"under local control", codec.StatusPresent | codec.StatusLocal, consumer.SlotStatePresent},
+		{"online but absent", codec.StatusOnline, consumer.SlotStateNoCard},
+	}
+	for _, tc := range tests {
+		if got := slotState(tc.status); got != tc.want {
+			t.Errorf("%s: %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestSessionServices covers what a control session asks for, and the one bit
+// that changes the answer.
+func TestSessionServices(t *testing.T) {
+	short := sessionServices(false)
+	long := sessionServices(true)
+
+	for _, want := range []codec.Service{codec.SvcMenus, codec.SvcControl, codec.SvcDisplay} {
+		if !short.Has(want) {
+			t.Errorf("a session should ask for %s", want)
+		}
+	}
+	// The file service is opened separately, because services are
+	// all-or-nothing and a unit without one must still be controllable.
+	if short.Has(codec.SvcFile) {
+		t.Error("the control session must not ask for the file service")
+	}
+
+	if short.LongStrings() {
+		t.Error("the 16-bit request must not carry the long-string bit")
+	}
+	if !long.LongStrings() {
+		t.Error("the 32-bit request must carry it")
+	}
+	if long&^codec.SvcLongStr != short {
+		t.Error("the two requests should differ in exactly that one bit")
+	}
+}
+
+// TestClientIdentity covers what we tell a peer we are. The type id is the
+// vendor's own for a routing client, so their tools show us as something they
+// recognise.
+func TestClientIdentity(t *testing.T) {
+	p := New(testDeps())
+	id := p.identity()
+
+	if id.ID.TypeID != codec.TypeIDRoutingIPShareClient {
+		t.Errorf("type id = %d, want the routing client id", id.ID.TypeID)
+	}
+	if id.ID.Name == "" {
+		t.Error("we should say what we are")
+	}
+	if _, err := id.AppendTo(nil); err != nil {
+		t.Errorf("our own identity must encode: %v", err)
+	}
+}
+
+func TestGenerationName(t *testing.T) {
+	if got := generationName(codec.SvcMenus); got != "16-bit" {
+		t.Errorf("= %q, want 16-bit", got)
+	}
+	if got := generationName(codec.SvcMenus | codec.SvcLongStr); got != "32-bit" {
+		t.Errorf("= %q, want 32-bit", got)
+	}
+}
+
+func TestDisplayLabel(t *testing.T) {
+	tests := []struct {
+		line int16
+		want string
+	}{
+		{codec.DisplayLineError, "error"},
+		{codec.DisplayLineWarning, "warning"},
+		{0, "display0"},
+		{3, "display3"},
+	}
+	for _, tc := range tests {
+		if got := displayLabel(tc.line); got != tc.want {
+			t.Errorf("displayLabel(%d) = %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+func TestPathString(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{"a"}, "a"},
+		{[]string{"a", "b", "c"}, "a.b.c"},
+	}
+	for _, tc := range tests {
+		if got := pathString(tc.in); got != tc.want {
+			t.Errorf("pathString(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFactoryNew covers construction through the registry's own path, which is
+// how the connector is actually built in service.
+func TestFactoryNew(t *testing.T) {
+	f := &Factory{}
+
+	p := f.New(plugin.Deps{})
+	if p == nil {
+		t.Fatal("the factory returned nothing")
+	}
+	// An empty dependency set is filled in rather than panicking.
+	if err := p.Disconnect(); err != nil {
+		t.Errorf("Disconnect on a fresh connector: %v", err)
+	}
+}
+
+// TestMenuLineScale covers the divisor's zero-means-one rule. Devices publish
+// a zero routinely, and dividing by it directly faults.
+func TestMenuLineScale(t *testing.T) {
+	if got := (menuLine{}).Scale(); got != 1 {
+		t.Errorf("Scale = %d, want 1 for a zero divisor", got)
+	}
+	if got := (menuLine{DivScale: 10}).Scale(); got != 10 {
+		t.Errorf("Scale = %d, want 10", got)
+	}
+}
+
+// TestRegistered covers the init that makes the connector reachable by name.
+// Without it the package compiles, the tests pass, and the CLI has never heard
+// of the protocol.
+func TestRegistered(t *testing.T) {
+	f, err := consumer.Get("rollcall")
+	if err != nil {
+		t.Fatalf("the connector is not registered: %v", err)
+	}
+	if f.Meta().Name != "rollcall" {
+		t.Errorf("registered as %q", f.Meta().Name)
+	}
+
+	var found bool
+	for _, name := range consumer.List() {
+		if name == "rollcall" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rollcall is missing from %v", consumer.List())
+	}
+}

--- a/internal/snell-rollcall/consumer/plugin.go
+++ b/internal/snell-rollcall/consumer/plugin.go
@@ -110,6 +110,9 @@ type Plugin struct {
 	// events is closed to stop the back-channel pump.
 	events chan struct{}
 
+	// fileCeiling bounds one file read. Zero takes DefaultMaxFileBytes.
+	fileCeiling int
+
 	// addr is what we were asked to connect to, kept for DeviceInfo.
 	addr string
 	port int

--- a/internal/snell-rollcall/consumer/plugin.go
+++ b/internal/snell-rollcall/consumer/plugin.go
@@ -1,0 +1,205 @@
+// Package rollcall is the outbound Snell RollCall connector.
+//
+// It implements consumer.Protocol on top of the session layer, which supplies
+// the link, the sessions and the back channel, and the codec, which supplies
+// the wire format for both generations.
+//
+// # How RollCall maps onto the neutral model
+//
+// A RollCall network is units, and a unit has ports. A gateway is a unit whose
+// ports are the cards in its frame, so the mapping in ADR-0022 falls out
+// naturally: the unit is the device, a port is a slot, and the type id and
+// version a port reports are the card's identity.
+//
+// An object is a menu line. Its command number is its id, its style says what
+// kind of value it holds and whether it may be written, and its position in the
+// menu gives its path.
+//
+// # Which generation
+//
+// A device may serve both, and which one a session speaks is decided when the
+// session opens, not by the device. The peer advertises long strings in its
+// service mask; a client that wants the 32-bit generation asks for the bit in
+// its Call. Services are all-or-nothing, so a peer that cannot supply it
+// refuses the whole call and the client retries without it.
+//
+// This connector asks for the 32-bit generation whenever the peer advertises
+// it, because it is the only one that can express a router's command space,
+// and falls back automatically otherwise.
+package rollcall
+
+import (
+	"log/slog"
+	"sync"
+
+	"dhs/internal/clock"
+	"dhs/internal/consumer"
+	"dhs/internal/metrics"
+	"dhs/internal/plugin"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+	"dhs/internal/transport"
+)
+
+// DefaultPort is the IPShare port. The vendor dissector decodes 2050 to 2060,
+// and a gateway listens on the first of those.
+const DefaultPort = 2050
+
+// Register this plugin on import.
+func init() {
+	consumer.Register(&Factory{})
+}
+
+// Factory builds Plugin instances.
+type Factory struct{}
+
+// Meta describes the connector to the registry.
+func (f *Factory) Meta() consumer.ProtocolMeta {
+	return consumer.ProtocolMeta{
+		Name:        "rollcall",
+		DefaultPort: DefaultPort,
+		Description: "Snell RollCall over IPShare, 16-bit and 32-bit generations",
+	}
+}
+
+// New builds a connector from the dependency set.
+func (f *Factory) New(deps plugin.Deps) consumer.Protocol {
+	return New(deps)
+}
+
+// New builds a connector. It opens nothing: Connect does that, through the
+// injected transport.
+func New(deps plugin.Deps) *Plugin {
+	deps = deps.WithDefaults()
+	return &Plugin{
+		log:    deps.Logger,
+		net:    deps.Net,
+		clk:    deps.Clock,
+		met:    deps.Metrics,
+		deps:   deps,
+		trees:  make(map[int]*slotTree),
+		subs:   make(map[subKey]consumer.EventFunc),
+		events: make(chan struct{}),
+	}
+}
+
+// Plugin is one connection to one RollCall gateway.
+type Plugin struct {
+	log  *slog.Logger
+	net  transport.Net
+	clk  clock.Clock
+	met  *metrics.Connector
+	deps plugin.Deps
+
+	mu sync.RWMutex
+
+	// link and its sessions are replaced wholesale on reconnect, so a caller
+	// holding a stale one cannot use it by accident.
+	link *link
+
+	// trees holds one walked menu per slot, which is what makes a label or a
+	// path resolvable without walking again.
+	trees map[int]*slotTree
+
+	subs map[subKey]consumer.EventFunc
+
+	// comp collects spec deviations. The connector absorbs each one and keeps
+	// running; the catalogue is what stops that being silent.
+	comp compliance
+
+	// events is closed to stop the back-channel pump.
+	events chan struct{}
+
+	// addr is what we were asked to connect to, kept for DeviceInfo.
+	addr string
+	port int
+}
+
+// subKey identifies a subscription. A zero command means every command on the
+// slot, which is what an empty label or id in the request asks for.
+type subKey struct {
+	slot    int
+	command uint32
+}
+
+// compile-time proof that the plugin satisfies the neutral contract.
+var _ consumer.Protocol = (*Plugin)(nil)
+
+// styleKind maps a menu line's style to the neutral value kind.
+//
+// The mapping is what makes a RollCall menu legible to a caller that has never
+// heard of RollCall, so it is worth being exact about the two that are not
+// obvious. A checkbox is a boolean rather than a small number, because that is
+// what a caller wants to set. A button carries no value at all: writing to it
+// is the action, and the value it writes is in its own range field.
+func styleKind(style codec.Style) consumer.ValueKind {
+	switch style.Kind() {
+	case codec.StyleCheckbox:
+		return consumer.KindBool
+
+	case codec.StyleNumber, codec.StyleVGraph, codec.StyleHGraph,
+		codec.StyleVLevel, codec.StyleHLevel, codec.StyleButton:
+		return consumer.KindInt
+
+	case codec.StyleEditString, codec.StyleDisplay:
+		return consumer.KindString
+
+	case codec.StyleList, codec.StyleTiled, codec.StylePartial:
+		// A container holds no value of its own; it is a node.
+		return consumer.KindUnknown
+
+	case codec.StyleData:
+		return consumer.KindRaw
+
+	case codec.StyleLink:
+		// A link names another unit rather than holding a value.
+		return consumer.KindString
+
+	default:
+		return consumer.KindUnknown
+	}
+}
+
+// Access bits, matching the neutral model's byte.
+const (
+	accessRead   uint8 = 0x01
+	accessWrite  uint8 = 0x02
+	accessSetDef uint8 = 0x04
+)
+
+// styleAccess maps a menu line's style to the neutral access bits.
+//
+// Everything readable is read; a disabled line is not writable; a container
+// and a display line are never writable. The preset bit is carried separately
+// on the value, so it is added by the walker when a line reports it.
+func styleAccess(style codec.Style) uint8 {
+	access := accessRead
+	if style.Disabled() {
+		return access
+	}
+	switch style.Kind() {
+	case codec.StyleTiled, codec.StyleList, codec.StylePartial, codec.StyleDisplay:
+		return access
+	default:
+		return access | accessWrite
+	}
+}
+
+// sessionServices is what a control-and-menu session asks for.
+//
+// Display is included because a unit's status lines are pushed on the same
+// session, and asking for it later would mean a second call. File is not:
+// it is opened on demand, so a unit without a file service is still usable.
+func sessionServices(longStrings bool) codec.Service {
+	s := codec.SvcMenus | codec.SvcControl | codec.SvcDisplay
+	if longStrings {
+		s |= codec.SvcLongStr
+	}
+	return s
+}
+
+// identity is what we present to a peer. The name is what appears in the
+// vendor's own session list, so it says what we are.
+func (p *Plugin) identity() codec.DeviceInfo {
+	return session.ClientIdentity("dhs rollcall", sessionServices(true))
+}

--- a/internal/snell-rollcall/consumer/services_test.go
+++ b/internal/snell-rollcall/consumer/services_test.go
@@ -1,0 +1,479 @@
+package rollcall
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// TestReadFile covers the service two things depend on: a router's names come
+// from a file, and the vendor's Control Panel will not render a device at all
+// without reading TEMPLATE.ZIP from it.
+func TestReadFile(t *testing.T) {
+	body := bytes.Repeat([]byte("RollCall template archive. "), 200)
+
+	h := newHarness(t, func(d *device) { d.setFile("TEMPLATE.ZIP", body) })
+
+	got, err := h.plugin.ReadFile(context.Background(), 0, "TEMPLATE.ZIP")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("read %d bytes, want %d, and they differ", len(got), len(body))
+	}
+	// The file is longer than one frame, so this also proves the block loop.
+	if len(body) <= codec.MaxPayload {
+		t.Fatal("the test file must be longer than a single frame")
+	}
+}
+
+// TestReadFile_HonoursTheDeviceBlockSize covers the figure an open reply
+// carries.
+//
+// Both numeric fields change meaning between the request and the reply: on the
+// way out the offset says where to read and the extra says how many bytes; on
+// the way back the offset is how many were read and the extra is the error.
+// The block size arrives in the open reply's offset, and honouring it is what
+// keeps a read within what the device is willing to hand over.
+func TestReadFile_HonoursTheDeviceBlockSize(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 500)
+
+	h := newHarness(t, func(d *device) {
+		d.blockSize = 64 // the device wants small blocks
+		d.setFile("NAMES.DAT", body)
+	})
+
+	got, err := h.plugin.ReadFile(context.Background(), 0, "NAMES.DAT")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("read %d bytes, want %d", len(got), len(body))
+	}
+}
+
+func TestReadFile_Missing(t *testing.T) {
+	h := newHarness(t, nil)
+
+	_, err := h.plugin.ReadFile(context.Background(), 0, "NOSUCH.BIN")
+	if err == nil {
+		t.Fatal("reading a file that is not there should fail")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("err = %v, want the device's own reason", err)
+	}
+}
+
+// TestReadFileTo covers the streaming form, for a caller that would rather not
+// hold a whole archive in memory.
+func TestReadFileTo(t *testing.T) {
+	body := bytes.Repeat([]byte("ab"), 1000)
+	h := newHarness(t, func(d *device) { d.setFile("BIG.BIN", body) })
+
+	var buf bytes.Buffer
+	n, err := h.plugin.ReadFileTo(context.Background(), 0, "BIG.BIN", &buf)
+	if err != nil {
+		t.Fatalf("ReadFileTo: %v", err)
+	}
+	if n != int64(len(body)) {
+		t.Errorf("wrote %d bytes, want %d", n, len(body))
+	}
+	if !bytes.Equal(buf.Bytes(), body) {
+		t.Error("the streamed bytes differ from the file")
+	}
+}
+
+// TestSubscribe_DeliversPushes covers the back channel end to end, and the two
+// messages it takes to open. Opening the channel is not enough on its own:
+// value pushes additionally need change reporting, and with only the first a
+// subscription looks live and nothing arrives.
+func TestSubscribe_DeliversPushes(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e })
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	value, err := codec.Value{
+		Command: 0x0113,
+		Mode:    codec.ModeValue,
+		Val:     -24,
+	}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetValue, value)
+
+	select {
+	case ev := <-events:
+		if ev.Slot != 1 {
+			t.Errorf("slot = %d", ev.Slot)
+		}
+		if ev.ID != 0x0113 {
+			t.Errorf("id = %d, want the command number", ev.ID)
+		}
+		if ev.Label != "Gain" {
+			t.Errorf("label = %q, want the menu's own label", ev.Label)
+		}
+		if ev.Value.Int != -24 {
+			t.Errorf("value = %d, want -24", ev.Value.Int)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the push was never delivered")
+	}
+}
+
+// TestSubscribe_AcknowledgesAfterDelivery pins the flow control. The
+// acknowledgement is what asks the device for the next push, so sending it
+// before the listener has taken this one throws that away.
+func TestSubscribe_AcknowledgesAfterDelivery(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	for i := range 3 {
+		value, err := codec.Value{
+			Command: 0x0113, Mode: codec.ModeValue, Val: int32(i),
+		}.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo: %v", err)
+		}
+		h.device.push(1, codec.MsgRetValue, value)
+	}
+
+	// All three arrive, which can only happen if each was acknowledged: the
+	// session layer holds the next push until the previous one is answered.
+	for i := range 3 {
+		select {
+		case ev := <-events:
+			if ev.Value.Int != int64(i) {
+				t.Errorf("push %d carried %d", i, ev.Value.Int)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of 3 pushes arrived; acknowledgements are not flowing", i)
+		}
+	}
+}
+
+// TestSubscribe_ByLabel covers a subscription to one object rather than a
+// whole slot.
+func TestSubscribe_ByLabel(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// A push for the subscribed command arrives.
+	wanted, _ := codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 1}.AppendTo(nil)
+	h.device.push(1, codec.MsgRetValue, wanted)
+
+	select {
+	case ev := <-events:
+		if ev.ID != 0x0113 {
+			t.Errorf("id = %d", ev.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the subscribed command was not delivered")
+	}
+
+	// One for a different command does not.
+	other, _ := codec.Value{Command: 0x0114, Mode: codec.ModeValue, Val: 1}.AppendTo(nil)
+	h.device.push(1, codec.MsgRetValue, other)
+
+	select {
+	case ev := <-events:
+		t.Errorf("a push for command %d reached a listener for another", ev.ID)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	req := consumer.ValueRequest{Slot: 1, Label: "Gain"}
+	if err := h.plugin.Subscribe(req, func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if err := h.plugin.Unsubscribe(req); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+
+	value, _ := codec.Value{Command: 0x0113, Mode: codec.ModeValue, Val: 5}.AppendTo(nil)
+	h.device.push(1, codec.MsgRetValue, value)
+
+	select {
+	case ev := <-events:
+		t.Errorf("a push arrived after unsubscribing: %+v", ev)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestSubscribe_NeedsACallback(t *testing.T) {
+	h := newHarness(t, nil)
+
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 0}, nil); err == nil {
+		t.Error("subscribing with no callback should be refused")
+	}
+}
+
+// TestSubscribe_MenuChangeInvalidatesTheWalk covers a device reconfiguring
+// itself. A cached menu is then wrong, so it is dropped rather than used to
+// report an access the card no longer has.
+func TestSubscribe_MenuChangeInvalidatesTheWalk(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	events := make(chan consumer.Event, 4)
+	if err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1},
+		func(e consumer.Event) { events <- e }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	h.plugin.mu.RLock()
+	cached := h.plugin.trees[1] != nil
+	h.plugin.mu.RUnlock()
+	if !cached {
+		t.Fatal("the walk was not cached")
+	}
+
+	h.device.push(1, codec.MsgFuncListChg, nil)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		h.plugin.mu.RLock()
+		still := h.plugin.trees[1] != nil
+		h.plugin.mu.RUnlock()
+		if !still {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("a menu change did not invalidate the cached walk")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestDisplay covers a unit's status lines, which are a separate service from
+// the menu: numbered rather than named, with two negative numbers reserved for
+// an error and a warning.
+func TestDisplay(t *testing.T) {
+	h := newHarness(t, nil)
+
+	lines, err := h.plugin.Display(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Display: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Errorf("got %d lines, want the device's 2", len(lines))
+	}
+	if lines[0] != "line 0" {
+		t.Errorf("line 0 = %q", lines[0])
+	}
+}
+
+// TestDevices covers discovery: a gateway keeps a map of what it has heard
+// announce itself, and walking that map is how a fleet is found.
+func TestDevices(t *testing.T) {
+	h := newHarness(t, nil)
+
+	devices, err := h.plugin.Devices(context.Background())
+	if err != nil {
+		t.Fatalf("Devices: %v", err)
+	}
+	if len(devices) == 0 {
+		t.Fatal("no devices found")
+	}
+	if devices[0].ID.Name != "Centra" {
+		t.Errorf("first device = %q", devices[0].ID.Name)
+	}
+	if got := codec.UnitTypeName(devices[0].ID.TypeID); got != "Router Matrix" {
+		t.Errorf("type = %q, want the product name", got)
+	}
+}
+
+func TestPorts(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 4 })
+
+	ports, err := h.plugin.Ports(context.Background(), gatewayAddr.Unit)
+	if err != nil {
+		t.Fatalf("Ports: %v", err)
+	}
+	if len(ports) != 4 {
+		t.Errorf("got %d ports, want 4", len(ports))
+	}
+}
+
+// TestBothGenerations runs the same reads and writes over each wire
+// generation, because a connector that serves only the one it was tested on
+// is half a connector.
+func TestBothGenerations(t *testing.T) {
+	tests := []struct {
+		name        string
+		longStrings bool
+	}{
+		{"32-bit", true},
+		{"16-bit", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, func(d *device) {
+				if !tc.longStrings {
+					d.services &^= codec.SvcLongStr
+				}
+				d.setMenu(1, testMenu())
+			})
+			ctx := context.Background()
+
+			long, err := h.plugin.Uses32Bit(ctx, 1)
+			if err != nil {
+				t.Fatalf("Uses32Bit: %v", err)
+			}
+			if long != tc.longStrings {
+				t.Fatalf("session is 32-bit = %v, want %v", long, tc.longStrings)
+			}
+
+			// Walk.
+			objects, err := h.plugin.Walk(ctx, 1)
+			if err != nil {
+				t.Fatalf("Walk: %v", err)
+			}
+			if len(objects) != len(testMenu()) {
+				t.Errorf("walked %d objects, want %d", len(objects), len(testMenu()))
+			}
+
+			// Read.
+			v, err := h.plugin.GetValue(ctx, consumer.ValueRequest{Slot: 1, Label: "Gain"})
+			if err != nil {
+				t.Fatalf("GetValue: %v", err)
+			}
+			if v.Kind != consumer.KindInt {
+				t.Errorf("kind = %s, want int", v.Kind)
+			}
+
+			// Write, and read back what the device stored.
+			got, err := h.plugin.SetValue(ctx,
+				consumer.ValueRequest{Slot: 1, Label: "Gain"},
+				consumer.Value{Kind: consumer.KindInt, Int: -30})
+			if err != nil {
+				t.Fatalf("SetValue: %v", err)
+			}
+			if got.Int != -30 {
+				t.Errorf("= %d, want -30", got.Int)
+			}
+		})
+	}
+}
+
+// TestValueWithBothNumberAndString covers the combination that is normal
+// rather than exceptional. A device answers a checksum with the number
+// -1686180113 and the string "0x9B7EEEEF", and a caller wants both: the number
+// to compare and the string to show.
+func TestValueWithBothNumberAndString(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{
+			Command: 0x0113,
+			Mode:    codec.ModeValue | codec.ModeString,
+			Val:     -1686180113,
+			Text:    "0x9B7EEEEF",
+		})
+	})
+
+	v, err := h.plugin.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Gain"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if v.Int != -1686180113 {
+		t.Errorf("number = %d", v.Int)
+	}
+	if v.Str != "0x9B7EEEEF" {
+		t.Errorf("string = %q, want the device's own rendering", v.Str)
+	}
+}
+
+// TestValueWithNoMode covers a reply that sets no flag and so carries nothing.
+// The object exists and the device simply said nothing about it, so an empty
+// value of the right kind is returned rather than an error, and the oddity is
+// recorded.
+func TestValueWithNoMode(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{Command: 0x0113})
+	})
+
+	v, err := h.plugin.GetValue(context.Background(), consumer.ValueRequest{Slot: 1, Label: "Gain"})
+	if err != nil {
+		t.Fatalf("GetValue: %v", err)
+	}
+	if v.Kind != consumer.KindInt {
+		t.Errorf("kind = %s, want the object's own kind", v.Kind)
+	}
+	if !hasEvent(h.plugin, EventValueModeEmpty) {
+		t.Error("a reply carrying nothing was not recorded")
+	}
+}
+
+// TestComplianceEventsAreCounted covers the catalogue's shape. A device that
+// misbehaves on every one of sixty-five thousand destinations must not fill
+// memory with the evidence, so repeats are counted rather than accumulated.
+func TestComplianceEventsAreCounted(t *testing.T) {
+	h := newHarness(t, nil)
+
+	for range 10 {
+		h.plugin.fire(EventValueModeEmpty, "detail")
+	}
+
+	events := h.plugin.ComplianceEvents()
+	if len(events) != 1 {
+		t.Fatalf("%d entries, want one per kind", len(events))
+	}
+	if events[0].Count != 10 {
+		t.Errorf("count = %d, want 10", events[0].Count)
+	}
+	if events[0].Name != EventValueModeEmpty {
+		t.Errorf("name = %q", events[0].Name)
+	}
+	if events[0].At.IsZero() {
+		t.Error("the event carries no time")
+	}
+}
+
+func TestUnitFromFormat(t *testing.T) {
+	tests := []struct {
+		format string
+		want   string
+	}{
+		{"%0.1f dB", "dB"},
+		{"%d", ""},
+		{"%d %%", "%%"},
+		{"%s", ""},
+		{"", ""},
+		{"no conversion here", ""},
+		{"%d frames", "frames"},
+	}
+	for _, tc := range tests {
+		if got := unitFromFormat(tc.format); got != tc.want {
+			t.Errorf("unitFromFormat(%q) = %q, want %q", tc.format, got, tc.want)
+		}
+	}
+}

--- a/internal/snell-rollcall/consumer/subscribe.go
+++ b/internal/snell-rollcall/consumer/subscribe.go
@@ -1,0 +1,318 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// Subscribe registers a listener for value changes on a slot.
+//
+// Two messages are needed and the second is easy to miss: opening the back
+// channel makes a session able to receive pushes, and asking for change
+// reporting is what makes a device send value pushes at all. With only the
+// first, a subscription looks live and nothing ever arrives.
+//
+// On enable the device flushes every value that has changed, so a burst
+// follows immediately. That is the specification's behaviour rather than a
+// fault, and it is what makes the first callback arrive without anything
+// having moved.
+func (p *Plugin) Subscribe(req consumer.ValueRequest, fn consumer.EventFunc) error {
+	if fn == nil {
+		return fmt.Errorf("rollcall: subscribe needs a callback")
+	}
+
+	ctx := context.Background()
+	s, err := p.session(ctx, uint8(req.Slot))
+	if err != nil {
+		return err
+	}
+
+	// Resolving the request needs the menu, so a subscription by label walks
+	// on a miss like every other addressed call.
+	//
+	// A subscription to the whole slot walks too, even though it needs no
+	// resolution: the menu is what gives a push its label and its path, and
+	// an event stream of bare command numbers is far less use than one that
+	// names what changed. It is best effort, because a device with no menu
+	// service can still push values.
+	var command uint32
+	if req.Path != "" || req.Label != "" || req.ID != 0 {
+		t, err := p.tree(ctx, req.Slot)
+		if err != nil {
+			return err
+		}
+		line, err := t.resolve(req)
+		if err != nil {
+			return err
+		}
+		command = line.Command
+	} else if _, err := p.tree(ctx, req.Slot); err != nil {
+		p.log.Debug("rollcall: subscribing without a menu; pushes will carry no labels",
+			"slot", req.Slot, "err", err)
+	}
+
+	p.mu.Lock()
+	p.subs[subKey{slot: req.Slot, command: command}] = fn
+	p.mu.Unlock()
+
+	if err := s.EnableBackChannel(ctx, true); err != nil {
+		p.mu.Lock()
+		delete(p.subs, subKey{slot: req.Slot, command: command})
+		p.mu.Unlock()
+		return err
+	}
+
+	go p.deliver(req.Slot, s)
+	return nil
+}
+
+// Unsubscribe removes a listener.
+//
+// The back channel itself is left open. A slot usually has more than one
+// subscription, and closing the channel for one of them would silence the
+// others; the device is told to stop only when the last goes.
+func (p *Plugin) Unsubscribe(req consumer.ValueRequest) error {
+	ctx := context.Background()
+
+	var command uint32
+	if req.Path != "" || req.Label != "" || req.ID != 0 {
+		t, err := p.tree(ctx, req.Slot)
+		if err != nil {
+			return err
+		}
+		line, err := t.resolve(req)
+		if err != nil {
+			return err
+		}
+		command = line.Command
+	}
+
+	p.mu.Lock()
+	delete(p.subs, subKey{slot: req.Slot, command: command})
+	remaining := 0
+	for k := range p.subs {
+		if k.slot == req.Slot {
+			remaining++
+		}
+	}
+	p.mu.Unlock()
+
+	if remaining > 0 {
+		return nil
+	}
+
+	s, err := p.session(ctx, uint8(req.Slot))
+	if err != nil {
+		// Nothing left to tell; the subscription is gone either way.
+		return nil //nolint:nilerr // an unreachable device needs no unsubscribe
+	}
+	return s.DisableBackChannel(ctx)
+}
+
+// deliver pumps one session's pushes into the registered callbacks.
+func (p *Plugin) deliver(slot int, s *session.Session) {
+	p.mu.RLock()
+	stop := p.events
+	p.mu.RUnlock()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case push, ok := <-s.Pushes():
+			if !ok {
+				return
+			}
+			p.dispatch(slot, push.Frame)
+
+			// The acknowledgement goes after the callbacks have run, because
+			// it is what asks the device for the next push. Sending it first
+			// throws away the only flow control the protocol offers, and a
+			// fast device would then outrun a slow listener.
+			if err := push.Ack(); err != nil {
+				p.log.Debug("rollcall: could not acknowledge a push",
+					"slot", slot, "err", err)
+				return
+			}
+		}
+	}
+}
+
+// dispatch turns one push into an event and delivers it.
+func (p *Plugin) dispatch(slot int, f codec.Frame) {
+	switch f.Type {
+	case codec.MsgRetFStat, codec.MsgSetParam:
+		fs, err := codec.DecodeFuncStatus(f.Payload)
+		if err != nil {
+			p.log.Debug("rollcall: undecodable value push", "slot", slot, "err", err)
+			return
+		}
+		p.emit(slot, uint32(fs.Command), fs.Mode, fs.Value, fs.Text, fs.Data)
+
+	case codec.MsgRetValue:
+		v, err := codec.DecodeValue(f.Payload)
+		if err != nil {
+			p.log.Debug("rollcall: undecodable value push", "slot", slot, "err", err)
+			return
+		}
+		p.emit(slot, v.Command, v.Mode, v.Val, v.Text, v.Data)
+
+	case codec.MsgDispData:
+		d, err := codec.DecodeDisp(f.Payload)
+		if err != nil {
+			return
+		}
+		p.emitDisplay(slot, d)
+
+	case codec.MsgFuncStyleChg:
+		// A style change means a line became hidden or disabled. The cached
+		// menu is now stale, so it is dropped and the next call walks again
+		// rather than reporting an access it no longer has.
+		p.invalidate(slot)
+
+	case codec.MsgFuncListChg:
+		// The whole menu changed, which happens when a card is reconfigured.
+		p.invalidate(slot)
+	}
+}
+
+// emit delivers a value change to whichever callbacks want it.
+func (p *Plugin) emit(slot int, command uint32, mode codec.Mode, num int32, text string, data []byte) {
+	p.mu.RLock()
+	specific := p.subs[subKey{slot: slot, command: command}]
+	all := p.subs[subKey{slot: slot}]
+	t := p.trees[slot]
+	p.mu.RUnlock()
+
+	if specific == nil && all == nil {
+		return
+	}
+
+	var line *menuLine
+	if t != nil {
+		if i, ok := t.byCmd[command]; ok {
+			line = &t.lines[i]
+		}
+	}
+	if line == nil {
+		// A device pushing a command its own menu does not list is the
+		// device's business; it knows its command set better than a cached
+		// walk does, so the event is delivered under its number.
+		p.fire(EventUnsolicitedCommand, fmt.Sprintf(
+			"slot %d pushed command %d, which the walked menu does not list", slot, command))
+	}
+
+	ev := consumer.Event{
+		Slot:      slot,
+		ID:        int(command),
+		Value:     p.valueFrom(line, mode, num, text, data),
+		Timestamp: p.clk.Now(),
+	}
+	if line != nil {
+		ev.Label = line.Text
+		ev.Path = pathString(line.path)
+	}
+
+	if specific != nil {
+		specific(ev)
+	}
+	// A listener registered for the whole slot hears it too. When the command
+	// is zero the two lookups found the same registration, so delivering
+	// again would call one callback twice for one change.
+	if all != nil && command != 0 {
+		all(ev)
+	}
+}
+
+// emitDisplay delivers a status-line change.
+//
+// The four display lines are a unit's front panel, and the two negative line
+// numbers are an error and a warning rather than positions. A line outside
+// both ranges is kept under its own number and reported, because it means the
+// device is using the service in a way the specification does not describe.
+func (p *Plugin) emitDisplay(slot int, d codec.Disp) {
+	p.mu.RLock()
+	all := p.subs[subKey{slot: slot}]
+	p.mu.RUnlock()
+
+	if all == nil {
+		return
+	}
+	if d.Line > 3 || d.Line < codec.DisplayLineWarning {
+		p.fire(EventDisplayLineOutOfRange, fmt.Sprintf(
+			"slot %d sent display line %d", slot, d.Line))
+	}
+
+	all(consumer.Event{
+		Slot:      slot,
+		ID:        int(d.Line),
+		Label:     displayLabel(d.Line),
+		Value:     consumer.Value{Kind: consumer.KindString, Str: d.Text},
+		Timestamp: p.clk.Now(),
+	})
+}
+
+// displayLabel names a status line. The negative numbers carry priority rather
+// than position, which is why they are named rather than numbered.
+func displayLabel(line int16) string {
+	switch line {
+	case codec.DisplayLineError:
+		return "error"
+	case codec.DisplayLineWarning:
+		return "warning"
+	default:
+		return fmt.Sprintf("display%d", line)
+	}
+}
+
+func pathString(path []string) string {
+	out := ""
+	for i, part := range path {
+		if i > 0 {
+			out += "."
+		}
+		out += part
+	}
+	return out
+}
+
+// invalidate drops a slot's cached menu so the next call walks again.
+func (p *Plugin) invalidate(slot int) {
+	p.mu.Lock()
+	delete(p.trees, slot)
+	p.mu.Unlock()
+}
+
+// pumpBackChannel forwards announcements the link receives outside any
+// session, which is how a unit says it has appeared or gone.
+func (p *Plugin) pumpBackChannel() {
+	p.mu.RLock()
+	l := p.link
+	stop := p.events
+	p.mu.RUnlock()
+
+	if l == nil {
+		return
+	}
+	for {
+		select {
+		case <-stop:
+			return
+		case <-l.sess.Done():
+			return
+		case f := <-l.sess.Unsolicited():
+			if f.Type == codec.MsgIam {
+				if info, err := codec.DecodeDeviceInfo(f.Payload); err == nil {
+					p.log.Debug("rollcall: announcement",
+						"unit", info.Address.String(),
+						"name", info.ID.Name,
+						"status", info.Status.Status.String())
+				}
+			}
+		}
+	}
+}

--- a/internal/snell-rollcall/consumer/value.go
+++ b/internal/snell-rollcall/consumer/value.go
@@ -90,15 +90,17 @@ func (p *Plugin) set16(ctx context.Context, s *session.Session, line *menuLine,
 			line.Command)
 	}
 
-	payload, err := codec.FuncStatus{
+	// The text is truncated to the field before encoding, so the encode has
+	// nothing left to refuse: the only way FuncStatus.AppendTo fails is a
+	// string that does not fit, and this one is cut to fit by construction.
+	// Truncating is what the older generation requires; the caller that wants
+	// its whole string needs a session that negotiated long strings.
+	payload, _ := codec.FuncStatus{
 		Command: uint16(line.Command),
 		Mode:    mode,
 		Value:   num,
 		Text:    codec.TruncateFixed(text, codec.MaxTextSize),
 	}.AppendTo(nil)
-	if err != nil {
-		return consumer.Value{}, err
-	}
 
 	reply, err := s.Do(ctx, codec.MsgSetParam, payload)
 	if err != nil {
@@ -153,16 +155,21 @@ func (p *Plugin) SetDefault(ctx context.Context, req consumer.ValueRequest) (con
 }
 
 // locate resolves a request to a menu line and the session to reach it on.
+//
+// The session comes first because the menu walk needs one anyway. Asking for
+// it afterwards would leave a failure path reachable only by a disconnection
+// landing in the gap between the two calls, which is a branch nothing can
+// exercise and nobody can reason about.
 func (p *Plugin) locate(ctx context.Context, req consumer.ValueRequest) (*menuLine, *session.Session, error) {
+	s, err := p.session(ctx, uint8(req.Slot))
+	if err != nil {
+		return nil, nil, err
+	}
 	t, err := p.tree(ctx, req.Slot)
 	if err != nil {
 		return nil, nil, err
 	}
 	line, err := t.resolve(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	s, err := p.session(ctx, uint8(req.Slot))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/snell-rollcall/consumer/value.go
+++ b/internal/snell-rollcall/consumer/value.go
@@ -1,0 +1,294 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// GetValue reads one object.
+//
+// The request is resolved against the walked menu, which is walked on demand
+// if this is the first thing asked of the slot. That is what lets a caller
+// name an object by label without knowing its command number.
+func (p *Plugin) GetValue(ctx context.Context, req consumer.ValueRequest) (consumer.Value, error) {
+	line, s, err := p.locate(ctx, req)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+
+	if s.Uses32Bit() {
+		return p.get32(ctx, s, line)
+	}
+	return p.get16(ctx, s, line)
+}
+
+func (p *Plugin) get16(ctx context.Context, s *session.Session, line *menuLine) (consumer.Value, error) {
+	if line.Command > 0xFFFF {
+		return consumer.Value{}, fmt.Errorf(
+			"rollcall: command %d needs the 32-bit generation, which this session did not negotiate",
+			line.Command)
+	}
+
+	reply, err := s.Do(ctx, codec.MsgGetFStat,
+		codec.GetFStat{Command: uint16(line.Command)}.AppendTo(nil))
+	if err != nil {
+		return consumer.Value{}, err
+	}
+	fs, err := codec.DecodeFuncStatus(reply.Payload)
+	if err != nil {
+		return consumer.Value{}, fmt.Errorf("rollcall: get %q: %w", line.Text, err)
+	}
+	return p.valueFrom(line, fs.Mode, fs.Value, fs.Text, fs.Data), nil
+}
+
+func (p *Plugin) get32(ctx context.Context, s *session.Session, line *menuLine) (consumer.Value, error) {
+	reply, err := s.Do(ctx, codec.MsgGetValue,
+		codec.GetValue{Command: line.Command}.AppendTo(nil))
+	if err != nil {
+		return consumer.Value{}, err
+	}
+	v, err := codec.DecodeValue(reply.Payload)
+	if err != nil {
+		return consumer.Value{}, fmt.Errorf("rollcall: get %q: %w", line.Text, err)
+	}
+	return p.valueFrom(line, v.Mode, v.Val, v.Text, v.Data), nil
+}
+
+// SetValue writes one object and returns what the device confirmed.
+//
+// The reply carries the device's own value rather than an acknowledgement, so
+// a caller that asked for something out of range learns what it actually got
+// without a second read. That is a property of the protocol worth relying on:
+// a device clamps silently, and only the reply says so.
+func (p *Plugin) SetValue(ctx context.Context, req consumer.ValueRequest, val consumer.Value) (consumer.Value, error) {
+	line, s, err := p.locate(ctx, req)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+
+	mode, num, text, err := p.encodeValue(line, val)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+
+	if s.Uses32Bit() {
+		return p.set32(ctx, s, line, mode, num, text)
+	}
+	return p.set16(ctx, s, line, mode, num, text)
+}
+
+func (p *Plugin) set16(ctx context.Context, s *session.Session, line *menuLine,
+	mode codec.Mode, num int32, text string) (consumer.Value, error) {
+
+	if line.Command > 0xFFFF {
+		return consumer.Value{}, fmt.Errorf(
+			"rollcall: command %d needs the 32-bit generation, which this session did not negotiate",
+			line.Command)
+	}
+
+	payload, err := codec.FuncStatus{
+		Command: uint16(line.Command),
+		Mode:    mode,
+		Value:   num,
+		Text:    codec.TruncateFixed(text, codec.MaxTextSize),
+	}.AppendTo(nil)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgSetParam, payload)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+	fs, err := codec.DecodeFuncStatus(reply.Payload)
+	if err != nil {
+		return consumer.Value{}, fmt.Errorf("rollcall: set %q: %w", line.Text, err)
+	}
+	return p.valueFrom(line, fs.Mode, fs.Value, fs.Text, fs.Data), nil
+}
+
+func (p *Plugin) set32(ctx context.Context, s *session.Session, line *menuLine,
+	mode codec.Mode, num int32, text string) (consumer.Value, error) {
+
+	payload, err := codec.Value{
+		Command: line.Command,
+		Mode:    mode,
+		Val:     num,
+		Text:    text,
+	}.AppendTo(nil)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgSetValue, payload)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+	v, err := codec.DecodeValue(reply.Payload)
+	if err != nil {
+		return consumer.Value{}, fmt.Errorf("rollcall: set %q: %w", line.Text, err)
+	}
+	return p.valueFrom(line, v.Mode, v.Val, v.Text, v.Data), nil
+}
+
+// SetDefault asks a device to restore an object to its own default.
+//
+// It is a distinct operation rather than a write of a known value, because the
+// default is the device's to decide. The preset flag is what asks for it, and
+// the numeric field is ignored: measured against a live device, the vendor's
+// own Control Panel sends zero with the flag set and gets the default back.
+func (p *Plugin) SetDefault(ctx context.Context, req consumer.ValueRequest) (consumer.Value, error) {
+	line, s, err := p.locate(ctx, req)
+	if err != nil {
+		return consumer.Value{}, err
+	}
+	if s.Uses32Bit() {
+		return p.set32(ctx, s, line, codec.ModePreset, 0, "")
+	}
+	return p.set16(ctx, s, line, codec.ModePreset, 0, "")
+}
+
+// locate resolves a request to a menu line and the session to reach it on.
+func (p *Plugin) locate(ctx context.Context, req consumer.ValueRequest) (*menuLine, *session.Session, error) {
+	t, err := p.tree(ctx, req.Slot)
+	if err != nil {
+		return nil, nil, err
+	}
+	line, err := t.resolve(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	s, err := p.session(ctx, uint8(req.Slot))
+	if err != nil {
+		return nil, nil, err
+	}
+	return line, s, nil
+}
+
+// valueFrom builds a neutral value from a reply.
+//
+// Both flags may be set at once and that is normal rather than exceptional: a
+// device returns a checksum as the number -1686180113 and the string
+// "0x9B7EEEEF", and a caller wants the string. So when a line is numeric the
+// number wins, and the string is kept as the raw form for anyone who wants
+// what the device meant to display.
+func (p *Plugin) valueFrom(line *menuLine, mode codec.Mode, num int32, text string, data []byte) consumer.Value {
+	kind := consumer.KindInt
+	if line != nil && line.Style != 0 {
+		kind = styleKind(line.Style)
+	}
+
+	switch {
+	case mode.Has(codec.ModeData):
+		return consumer.Value{Kind: consumer.KindRaw, Raw: append([]byte(nil), data...)}
+
+	case kind == consumer.KindBool && mode.Has(codec.ModeValue):
+		return consumer.Value{Kind: consumer.KindBool, Bool: num != 0, Int: int64(num)}
+
+	case kind == consumer.KindString && mode.Has(codec.ModeString):
+		return consumer.Value{Kind: consumer.KindString, Str: text}
+
+	case mode.Has(codec.ModeValue):
+		v := consumer.Value{Kind: consumer.KindInt, Int: int64(num)}
+		if mode.Has(codec.ModeString) {
+			// The device supplied its own rendering, which is what a display
+			// should show; keep it beside the number rather than choosing.
+			v.Str = text
+			v.Raw = []byte(text)
+		}
+		return v
+
+	case mode.Has(codec.ModeString):
+		return consumer.Value{Kind: consumer.KindString, Str: text}
+
+	default:
+		// A reply that sets no flag carries nothing. Report it and return an
+		// empty value of the right kind rather than an error: the object
+		// exists, the device simply said nothing about it.
+		if line != nil {
+			p.fire(EventValueModeEmpty, fmt.Sprintf(
+				"command %d answered with mode %s and no value", line.Command, mode))
+		}
+		return consumer.Value{Kind: kind}
+	}
+}
+
+// encodeValue turns a neutral value into the mode, number and text a write
+// carries.
+func (p *Plugin) encodeValue(line *menuLine, val consumer.Value) (codec.Mode, int32, string, error) {
+	switch val.Kind {
+	case consumer.KindBool:
+		n := int32(0)
+		if val.Bool {
+			n = 1
+		}
+		return codec.ModeValue, n, "", nil
+
+	case consumer.KindInt:
+		return codec.ModeValue, int32(val.Int), "", nil
+
+	case consumer.KindUint:
+		return codec.ModeValue, int32(val.Uint), "", nil
+
+	case consumer.KindFloat:
+		// A menu line carries an integer scaled by its divisor, so a caller
+		// working in the displayed units is converted back into wire units
+		// here rather than having to know the divisor.
+		return codec.ModeValue, int32(val.Float * float64(line.Scale())), "", nil
+
+	case consumer.KindString:
+		return codec.ModeString, 0, val.Str, nil
+
+	case consumer.KindRaw:
+		return 0, 0, "", fmt.Errorf("rollcall: writing raw data is not supported on command %d", line.Command)
+
+	case consumer.KindUnknown:
+		// A caller that supplied no kind but did supply a number means the
+		// number, which is the common case from a command line.
+		if val.Int != 0 || val.Str == "" {
+			return codec.ModeValue, int32(val.Int), "", nil
+		}
+		return codec.ModeString, 0, val.Str, nil
+
+	default:
+		return 0, 0, "", fmt.Errorf("rollcall: cannot write a %s value", val.Kind)
+	}
+}
+
+// Display returns the unit's status lines, which are the four lines its front
+// panel shows.
+//
+// They are not menu objects: they are a separate service whose lines are
+// numbered rather than named, with two negative numbers reserved for an error
+// and a warning. That is why they have their own accessor rather than
+// appearing in a walk.
+func (p *Plugin) Display(ctx context.Context, slot int) (map[int16]string, error) {
+	s, err := p.session(ctx, uint8(slot))
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[int16]string, 4)
+	for line := int16(0); line < 4; line++ {
+		reply, err := s.Do(ctx, codec.MsgGetDispData,
+			[]byte{byte(uint16(line) >> 8), byte(uint16(line))})
+		if err != nil {
+			// A unit without a display service refuses the first line; that
+			// is an answer rather than a failure.
+			if line == 0 {
+				return nil, err
+			}
+			break
+		}
+		d, err := codec.DecodeDisp(reply.Payload)
+		if err != nil {
+			return nil, fmt.Errorf("rollcall: display line %d: %w", line, err)
+		}
+		out[d.Line] = d.Text
+	}
+	return out, nil
+}

--- a/internal/snell-rollcall/consumer/verbs_test.go
+++ b/internal/snell-rollcall/consumer/verbs_test.go
@@ -1,0 +1,415 @@
+package rollcall
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// allVerbs is every operation the connector offers, so a change in how one of
+// them fails cannot quietly diverge from the rest.
+//
+// The two tables below run all of them against a device that will not open a
+// session, and against a connector that was never connected. Both are ordinary
+// conditions in service: a unit runs out of sessions, and a caller forgets to
+// connect. Neither may return a zero value as though it had succeeded.
+func allVerbs() []struct {
+	name string
+	call func(context.Context, *Plugin) error
+} {
+	return []struct {
+		name string
+		call func(context.Context, *Plugin) error
+	}{
+		{"GetDeviceInfo", func(ctx context.Context, p *Plugin) error {
+			_, err := p.GetDeviceInfo(ctx)
+			return err
+		}},
+		{"GetSlotInfo", func(ctx context.Context, p *Plugin) error {
+			_, err := p.GetSlotInfo(ctx, 1)
+			return err
+		}},
+		{"Walk", func(ctx context.Context, p *Plugin) error {
+			_, err := p.Walk(ctx, 1)
+			return err
+		}},
+		{"GetValue", func(ctx context.Context, p *Plugin) error {
+			_, err := p.GetValue(ctx, consumer.ValueRequest{Slot: 1, ID: 1})
+			return err
+		}},
+		{"SetValue", func(ctx context.Context, p *Plugin) error {
+			_, err := p.SetValue(ctx, consumer.ValueRequest{Slot: 1, ID: 1},
+				consumer.Value{Kind: consumer.KindInt, Int: 1})
+			return err
+		}},
+		{"SetDefault", func(ctx context.Context, p *Plugin) error {
+			_, err := p.SetDefault(ctx, consumer.ValueRequest{Slot: 1, ID: 1})
+			return err
+		}},
+		{"Display", func(ctx context.Context, p *Plugin) error {
+			_, err := p.Display(ctx, 1)
+			return err
+		}},
+		{"Devices", func(ctx context.Context, p *Plugin) error {
+			_, err := p.Devices(ctx)
+			return err
+		}},
+		{"Ports", func(ctx context.Context, p *Plugin) error {
+			_, err := p.Ports(ctx, gatewayAddr.Unit)
+			return err
+		}},
+		{"Uses32Bit", func(ctx context.Context, p *Plugin) error {
+			_, err := p.Uses32Bit(ctx, 1)
+			return err
+		}},
+		{"ReadFile", func(ctx context.Context, p *Plugin) error {
+			_, err := p.ReadFile(ctx, 0, "A.BIN")
+			return err
+		}},
+		{"ReadFileTo", func(ctx context.Context, p *Plugin) error {
+			_, err := p.ReadFileTo(ctx, 0, "A.BIN", &bytes.Buffer{})
+			return err
+		}},
+		{"ListDir", func(ctx context.Context, p *Plugin) error {
+			_, err := p.ListDir(ctx, 0, "/")
+			return err
+		}},
+		{"Subscribe", func(_ context.Context, p *Plugin) error {
+			return p.Subscribe(consumer.ValueRequest{Slot: 1}, func(consumer.Event) {})
+		}},
+		{"Unsubscribe", func(_ context.Context, p *Plugin) error {
+			return p.Unsubscribe(consumer.ValueRequest{Slot: 1, ID: 1})
+		}},
+	}
+}
+
+// TestEveryVerbFailsWhenNoSessionCanBeOpened covers a unit that has run out of
+// sessions, which is the ordinary way a busy device stops being usable.
+func TestEveryVerbFailsWhenNoSessionCanBeOpened(t *testing.T) {
+	for _, tc := range allVerbs() {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, func(d *device) { d.refuse[codec.MsgCall] = true })
+			if err := tc.call(context.Background(), h.plugin); err == nil {
+				t.Errorf("%s succeeded on a device that opened no session", tc.name)
+			}
+		})
+	}
+}
+
+// TestEveryVerbFailsWhenNotConnected covers a caller that forgot to connect.
+func TestEveryVerbFailsWhenNotConnected(t *testing.T) {
+	for _, tc := range allVerbs() {
+		t.Run(tc.name, func(t *testing.T) {
+			p := New(testDeps())
+			err := tc.call(context.Background(), p)
+			if err == nil {
+				t.Fatalf("%s succeeded on a connector that was never connected", tc.name)
+			}
+			if !errors.Is(err, consumer.ErrNotConnected) {
+				t.Errorf("%s err = %v, want ErrNotConnected", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestEveryVerbFailsAfterDisconnect covers the same verbs once the link has
+// been taken away, which is what happens when a device is unplugged.
+func TestEveryVerbFailsAfterDisconnect(t *testing.T) {
+	for _, tc := range allVerbs() {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, func(d *device) {
+				d.setMenu(1, testMenu())
+				d.setFile("A.BIN", []byte("x"))
+			})
+			if err := h.plugin.Disconnect(); err != nil {
+				t.Fatalf("Disconnect: %v", err)
+			}
+			if err := tc.call(context.Background(), h.plugin); err == nil {
+				t.Errorf("%s succeeded after disconnecting", tc.name)
+			}
+		})
+	}
+}
+
+// TestGetSlotInfoRefusalsPerStep covers a device that answers one step of the
+// slot query and refuses the next, so the failure is attributed to the step
+// that actually failed rather than the first one.
+func TestGetSlotInfoRefusalsPerStep(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetStat] = true })
+
+	_, err := h.plugin.GetSlotInfo(context.Background(), 1)
+	if err == nil {
+		t.Fatal("a refused status should fail the slot query")
+	}
+}
+
+// TestReadFile_CloseFails covers a device that will not close a handle. The
+// read has already succeeded, so the caller gets its bytes: a file service
+// that cannot tidy up is a leak on the device, not a failed read.
+func TestReadFile_CloseFails(t *testing.T) {
+	body := []byte("contents")
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", body)
+		d.refuse[codec.MsgFileClose] = true
+	})
+
+	got, err := h.plugin.ReadFile(context.Background(), 0, "A.BIN")
+	if err != nil {
+		t.Fatalf("a failed close must not fail the read: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("read %q, want %q", got, body)
+	}
+}
+
+// TestReadFileTo_WriterFails covers the destination refusing the bytes, which
+// is what a full disk looks like. The error is the writer's, and how much was
+// written is reported so a caller can say where it stopped.
+func TestReadFileTo_WriterFails(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", bytes.Repeat([]byte("x"), 1000))
+	})
+
+	want := errors.New("disk full")
+	n, err := h.plugin.ReadFileTo(context.Background(), 0, "A.BIN", failingWriter{err: want})
+	if !errors.Is(err, want) {
+		t.Fatalf("err = %v, want the writer's own reason", err)
+	}
+	if n != 0 {
+		t.Errorf("wrote %d bytes, want the count the writer accepted", n)
+	}
+}
+
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write(p []byte) (int, error) { return 0, f.err }
+
+// TestReadFile_ReadRefused covers a device that opens a file and then refuses
+// to read from it.
+func TestReadFile_ReadRefused(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setFile("A.BIN", []byte("x"))
+		d.refuse[codec.MsgFileRead] = true
+	})
+	ctx := context.Background()
+
+	if _, err := h.plugin.ReadFile(ctx, 0, "A.BIN"); err == nil {
+		t.Error("a refused read should fail")
+	}
+	if _, err := h.plugin.ReadFileTo(ctx, 0, "A.BIN", &bytes.Buffer{}); err == nil {
+		t.Error("a refused read should fail the streaming form too")
+	}
+}
+
+// TestReadFileTo_Missing covers the streaming form against a file that is not
+// there.
+func TestReadFileTo_Missing(t *testing.T) {
+	h := newHarness(t, nil)
+
+	if _, err := h.plugin.ReadFileTo(context.Background(), 0, "NOSUCH.BIN", &bytes.Buffer{}); err == nil {
+		t.Error("streaming a file that is not there should fail")
+	}
+}
+
+// TestWalk16_SkipsUnexpectedItems covers a server answering one item of a
+// menu transfer with something other than a menu line. The rest of the menu is
+// still worth having, so the odd item is skipped rather than the walk
+// abandoned.
+func TestWalk16_SkipsUnexpectedItems(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services &^= codec.SvcLongStr
+		d.setMenu(1, testMenu())
+		d.oddMenuItem = 2 // the third line comes back as an acknowledgement
+	})
+
+	objects, err := h.plugin.Walk(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if len(objects) != len(testMenu())-1 {
+		t.Errorf("walked %d objects, want the menu less the odd one", len(objects))
+	}
+}
+
+// TestDevices_EmptyMapFallsBackToTheGateway covers a gateway that has heard
+// nothing announce itself. It still knows about itself, and reporting nothing
+// at all would look like a failed discovery.
+func TestDevices_EmptyMapFallsBackToTheGateway(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.emptyDeviceMap = true })
+
+	devices, err := h.plugin.Devices(context.Background())
+	if err != nil {
+		t.Fatalf("Devices: %v", err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("got %d devices, want the gateway itself", len(devices))
+	}
+	if devices[0].ID.Name != "Centra" {
+		t.Errorf("= %q, want the gateway", devices[0].ID.Name)
+	}
+}
+
+// TestUnsubscribeLeavesOtherListeners covers removing one subscription from a
+// slot that has more than one. Closing the back channel for one would silence
+// the others, so the device is told to stop only when the last goes.
+func TestUnsubscribeLeavesOtherListeners(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	events := make(chan consumer.Event, 8)
+	gain := consumer.ValueRequest{Slot: 1, Label: "Gain"}
+	enable := consumer.ValueRequest{Slot: 1, Label: "Enable"}
+
+	for _, req := range []consumer.ValueRequest{gain, enable} {
+		if err := h.plugin.Subscribe(req, func(e consumer.Event) { events <- e }); err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	}
+	if err := h.plugin.Unsubscribe(gain); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+
+	// The other listener still hears its own command.
+	value, err := codec.Value{Command: 0x0114, Mode: codec.ModeValue, Val: 1}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.push(1, codec.MsgRetValue, value)
+
+	select {
+	case ev := <-events:
+		if ev.ID != 0x0114 {
+			t.Errorf("id = %d, want the surviving subscription's command", ev.ID)
+		}
+	case <-timeoutAfter():
+		t.Fatal("removing one subscription silenced another")
+	}
+}
+
+// TestSubscribeUnresolvable covers subscribing to something the menu does not
+// contain.
+func TestSubscribeUnresolvable(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1, Label: "nothing"},
+		func(consumer.Event) {})
+	if err == nil {
+		t.Error("subscribing to an object that is not there should say so")
+	}
+}
+
+// TestSubscribeRefused covers a device that will not open its back channel.
+// The subscription must not be left registered, or a later push would be
+// delivered to a listener that was told it had failed.
+func TestSubscribeRefused(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.refuse[codec.MsgBkChnReady] = true
+	})
+
+	err := h.plugin.Subscribe(consumer.ValueRequest{Slot: 1, Label: "Gain"},
+		func(consumer.Event) {})
+	if err == nil {
+		t.Fatal("a refused back channel should fail the subscription")
+	}
+
+	h.plugin.mu.RLock()
+	left := len(h.plugin.subs)
+	h.plugin.mu.RUnlock()
+	if left != 0 {
+		t.Errorf("%d subscriptions were left registered after a failure", left)
+	}
+}
+
+// TestSetValueOnAnUnwalkedSlot covers a write that has to walk first, and one
+// to a command the menu does not list.
+func TestSetValueOnAnUnwalkedSlot(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, testMenu())
+		d.setValue(1, codec.Value{Command: 999, Mode: codec.ModeValue})
+	})
+
+	// A command the menu does not list is still addressable: the device knows
+	// its own command set better than a cached walk does.
+	got, err := h.plugin.SetValue(context.Background(),
+		consumer.ValueRequest{Slot: 1, ID: 999},
+		consumer.Value{Kind: consumer.KindInt, Int: 4})
+	if err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	if got.Int != 4 {
+		t.Errorf("= %d, want 4", got.Int)
+	}
+}
+
+// TestCallRefusedOnA16BitDevice covers a device that never advertised long
+// strings and still will not open a session. The connector must not try a
+// fallback it already knows is the same request.
+func TestCallRefusedOnA16BitDevice(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services &^= codec.SvcLongStr
+		d.refuse[codec.MsgCall] = true
+	})
+
+	_, err := h.plugin.Walk(context.Background(), 1)
+	if err == nil {
+		t.Fatal("a refused call should fail")
+	}
+	// There is nothing to fall back from, so nothing is reported as one.
+	if hasEvent(h.plugin, EventLongStringsRefused) {
+		t.Error("a device that never advertised long strings did not refuse them")
+	}
+}
+
+// TestListsSkipUnexpectedItems covers a gateway answering one item of a device
+// or port list with something other than a device record. The rest of the list
+// is still worth having.
+func TestListsSkipUnexpectedItems(t *testing.T) {
+	t.Run("port list", func(t *testing.T) {
+		h := newHarness(t, func(d *device) {
+			d.ports = 3
+			d.oddListItem = 1
+		})
+		ports, err := h.plugin.Ports(context.Background(), gatewayAddr.Unit)
+		if err != nil {
+			t.Fatalf("Ports: %v", err)
+		}
+		if len(ports) != 2 {
+			t.Errorf("got %d ports, want the list less the odd one", len(ports))
+		}
+	})
+
+	t.Run("device map", func(t *testing.T) {
+		h := newHarness(t, func(d *device) { d.oddListItem = 0 })
+		devices, err := h.plugin.Devices(context.Background())
+		if err != nil {
+			t.Fatalf("Devices: %v", err)
+		}
+		// Nothing decodable came back, so the gateway itself is the answer.
+		if len(devices) != 1 || devices[0].ID.Name != "Centra" {
+			t.Errorf("= %d devices, want the gateway itself", len(devices))
+		}
+	})
+}
+
+// TestLinkCloseIsIdempotent covers the guard on the link's own shutdown. It is
+// reached directly because Disconnect takes the link out of the plugin before
+// closing it, so nothing in service can close one twice; the guard is what
+// makes that safe rather than assumed.
+func TestLinkCloseIsIdempotent(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+
+	if _, err := h.plugin.Walk(context.Background(), 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+
+	l.close()
+	l.close() // must not panic, and must not close a session twice
+}

--- a/internal/snell-rollcall/consumer/walk.go
+++ b/internal/snell-rollcall/consumer/walk.go
@@ -1,0 +1,376 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"dhs/internal/consumer"
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// slotTree is a walked menu: the lines as they arrived, plus the indexes that
+// make a label or a path resolvable without walking again.
+type slotTree struct {
+	slot    int
+	lines   []menuLine
+	byLabel map[string]int // lowercased label to line index
+	byPath  map[string]int // lowercased dotted path to line index
+	byCmd   map[uint32]int
+	objects []consumer.Object
+}
+
+// menuLine is one menu entry, normalised across the two generations so that
+// nothing above this point has to know which one delivered it.
+type menuLine struct {
+	Index    uint32
+	Style    codec.Style
+	Command  uint32
+	MinRange int32
+	MaxRange int32
+	Step     uint32
+	DivScale uint16
+	Text     string
+	Param    string
+
+	// path is the line's position in the tree, containers first.
+	path []string
+
+	// children are the indices of the lines directly below a container.
+	children []int
+}
+
+// Scale returns the divisor with the zero-means-one rule applied.
+func (m menuLine) Scale() uint16 {
+	if m.DivScale == 0 {
+		return 1
+	}
+	return m.DivScale
+}
+
+// AccessGated reports whether the server substituted this line because it sits
+// above the session's user level.
+func (m menuLine) AccessGated() bool {
+	return codec.AccessGated(m.Style, m.Command, m.Text)
+}
+
+// Walk enumerates every menu line on a slot and returns them as objects.
+//
+// A slot is a port on the gateway unit, and a menu is walked on that port's
+// own session, which is what makes the lines belong to the card rather than to
+// the frame.
+func (p *Plugin) Walk(ctx context.Context, slot int) ([]consumer.Object, error) {
+	tree, err := p.walkTree(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	return tree.objects, nil
+}
+
+// walkTree walks a slot and caches the result.
+func (p *Plugin) walkTree(ctx context.Context, slot int) (*slotTree, error) {
+	if slot < 0 || slot > 0xFF {
+		return nil, fmt.Errorf("rollcall: slot %d is outside the port range", slot)
+	}
+
+	s, err := p.session(ctx, uint8(slot))
+	if err != nil {
+		return nil, err
+	}
+
+	var lines []menuLine
+	if s.Uses32Bit() {
+		lines, err = p.walk32(ctx, s)
+	} else {
+		lines, err = p.walk16(ctx, s)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	tree := buildTree(slot, lines, p)
+
+	p.mu.Lock()
+	p.trees[slot] = tree
+	p.mu.Unlock()
+	return tree, nil
+}
+
+// walk16 reads a menu in the original generation.
+//
+// The transfer is stateful: a request opens it, the server remembers the base,
+// and each fetch names an offset from that base. So the whole walk has to
+// happen on one session with nothing interleaved, which the session layer's
+// one-in-flight rule already guarantees.
+func (p *Plugin) walk16(ctx context.Context, s *session.Session) ([]menuLine, error) {
+	var lines []menuLine
+
+	err := session.Walk(ctx, s, codec.MsgGetFunc, []byte{0, 0},
+		func(_ int, f codec.Frame) error {
+			if f.Type != codec.MsgRetFunc {
+				// A server may answer an item with something else; skip it
+				// rather than abandon the menu.
+				return nil
+			}
+			fn, err := codec.DecodeFunc(f.Payload)
+			if err != nil {
+				return err
+			}
+			lines = append(lines, menuLine{
+				Index:    uint32(fn.MenuIndex),
+				Style:    fn.Style,
+				Command:  uint32(fn.Command),
+				MinRange: fn.MinRange,
+				MaxRange: fn.MaxRange,
+				Step:     uint32(fn.Step),
+				DivScale: fn.DivScale,
+				Text:     fn.Text,
+				Param:    fn.Param,
+			})
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: walk menu: %w", err)
+	}
+	return lines, nil
+}
+
+// walk32 reads a menu in the long-string generation.
+//
+// Every item is fetched by absolute index and the server holds no state, so a
+// caller could fetch them in any order. They are read in order anyway, because
+// a menu is a tree written depth-first and the spans only mean anything read
+// that way.
+func (p *Plugin) walk32(ctx context.Context, s *session.Session) ([]menuLine, error) {
+	var lines []menuLine
+
+	err := session.WalkMenu32(ctx, s, 0, func(m codec.MenuItem) error {
+		lines = append(lines, menuLine{
+			Index:    m.MenuIndex,
+			Style:    m.Style,
+			Command:  m.Command,
+			MinRange: m.MinRange,
+			MaxRange: m.MaxRange,
+			Step:     m.Step,
+			DivScale: m.DivScale,
+			Text:     m.Text,
+			Param:    m.Param,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: walk menu: %w", err)
+	}
+	return lines, nil
+}
+
+// buildTree turns a flat menu into a tree and an object list.
+//
+// This is where the menu model earns its comment. The array is flat, and a
+// container line's step field is the span of its whole subtree, not the count
+// of its immediate children. So reconstructing the tree is a pre-order walk
+// that consumes that many following entries, recursing into each container it
+// meets. Reading the step as a child count nests everything below the second
+// level in the wrong place, and the result still looks like a tree.
+func buildTree(slot int, lines []menuLine, p *Plugin) *slotTree {
+	t := &slotTree{
+		slot:    slot,
+		lines:   lines,
+		byLabel: make(map[string]int, len(lines)),
+		byPath:  make(map[string]int, len(lines)),
+		byCmd:   make(map[uint32]int, len(lines)),
+	}
+
+	var assign func(start, end int, prefix []string) int
+	assign = func(start, end int, prefix []string) int {
+		i := start
+		for i < end {
+			line := &t.lines[i]
+			line.path = append(append([]string{}, prefix...), line.Text)
+
+			span := 0
+			if line.Style.Container() {
+				span = int(line.Step)
+				if start+1+span > end {
+					// The line claims a subtree longer than what follows it.
+					// Clamp rather than run off the end, and say so.
+					if p != nil {
+						p.fire(EventMenuSpanOverruns, fmt.Sprintf(
+							"slot %d line %d claims a span of %d with %d lines left",
+							slot, line.Index, span, end-i-1))
+					}
+					span = end - i - 1
+				}
+			}
+			if span > 0 {
+				kids := assign(i+1, i+1+span, line.path)
+				for k := i + 1; k < i+1+span; k++ {
+					if len(t.lines[k].path) == len(line.path)+1 {
+						line.children = append(line.children, k)
+					}
+				}
+				_ = kids
+			}
+			i += 1 + span
+		}
+		return i
+	}
+	assign(0, len(lines), nil)
+
+	for i := range t.lines {
+		line := &t.lines[i]
+
+		if label := strings.ToLower(line.Text); label != "" {
+			if _, taken := t.byLabel[label]; !taken {
+				t.byLabel[label] = i
+			}
+		}
+		if path := strings.ToLower(strings.Join(line.path, ".")); path != "" {
+			if _, taken := t.byPath[path]; !taken {
+				t.byPath[path] = i
+			}
+		}
+		if line.Command != 0 {
+			if prev, taken := t.byCmd[line.Command]; taken {
+				if p != nil {
+					p.fire(EventDuplicateCommand, fmt.Sprintf(
+						"slot %d command %d is claimed by both %q and %q",
+						slot, line.Command, t.lines[prev].Text, line.Text))
+				}
+			} else {
+				t.byCmd[line.Command] = i
+			}
+		}
+		if line.AccessGated() && p != nil {
+			p.fire(EventAccessGated, fmt.Sprintf(
+				"slot %d line %d is above the session user level", slot, line.Index))
+		}
+	}
+
+	t.objects = make([]consumer.Object, 0, len(t.lines))
+	for i := range t.lines {
+		t.objects = append(t.objects, t.lines[i].object(slot))
+	}
+	return t
+}
+
+// object renders one menu line as a neutral object.
+func (m menuLine) object(slot int) consumer.Object {
+	o := consumer.Object{
+		Slot:   slot,
+		ID:     int(m.Command),
+		Path:   m.path,
+		Label:  m.Text,
+		Kind:   styleKind(m.Style),
+		Access: styleAccess(m.Style),
+	}
+	if len(m.path) > 0 {
+		o.Group = m.path[0]
+	}
+
+	// A container is a node in the tree rather than a value, so it carries no
+	// range and is marked as the section header it is.
+	if m.Style.Container() {
+		o.SubGroupMarker = true
+		return o
+	}
+
+	switch o.Kind {
+	case consumer.KindInt:
+		o.Min = int64(m.MinRange)
+		o.Max = int64(m.MaxRange)
+		if m.Step > 0 {
+			o.Step = int64(m.Step)
+		}
+		// The format string is the closest thing a menu line has to a unit:
+		// "%d dB" says the number is decibels.
+		o.Unit = unitFromFormat(m.Param)
+
+	case consumer.KindString:
+		// A string line's range is a length rather than a value.
+		if m.MaxRange > 0 {
+			o.MaxLen = int(m.MaxRange)
+		}
+
+	case consumer.KindBool:
+		// A checkbox's "on" value lives in the minimum-range field, which is
+		// conventionally one and occasionally not.
+		o.Min = int64(0)
+		o.Max = int64(1)
+	}
+	return o
+}
+
+// unitFromFormat extracts a unit from a printf format string.
+//
+// A menu line's format is what the device wants displayed, so "%0.1f dB"
+// carries both the precision and the unit. Everything after the conversion is
+// the unit; a format with no conversion has none.
+func unitFromFormat(format string) string {
+	i := strings.IndexByte(format, '%')
+	if i < 0 {
+		return ""
+	}
+	rest := format[i+1:]
+	for j := 0; j < len(rest); j++ {
+		switch rest[j] {
+		case 'd', 'f', 'g', 'e', 's', 'x', 'X', 'u', 'c':
+			return strings.TrimSpace(rest[j+1:])
+		}
+	}
+	return ""
+}
+
+// tree returns a slot's walked menu, walking it if there is none.
+//
+// This is what makes a label or a path resolve cold: the first request that
+// needs one walks, and every later one uses what it found.
+func (p *Plugin) tree(ctx context.Context, slot int) (*slotTree, error) {
+	p.mu.RLock()
+	t := p.trees[slot]
+	p.mu.RUnlock()
+
+	if t != nil {
+		return t, nil
+	}
+	return p.walkTree(ctx, slot)
+}
+
+// resolve finds the menu line a request addresses.
+//
+// The order follows the neutral contract: an explicit path first, because it
+// is unambiguous; then a label; then a command number. A command number of
+// zero with no label is not an address, because zero is what a container and a
+// gated placeholder both carry.
+func (t *slotTree) resolve(req consumer.ValueRequest) (*menuLine, error) {
+	if req.Path != "" {
+		if i, ok := t.byPath[strings.ToLower(req.Path)]; ok {
+			return &t.lines[i], nil
+		}
+		// A path that names one line is also accepted, because a caller that
+		// knows a label often writes it as a path.
+		if i, ok := t.byLabel[strings.ToLower(req.Path)]; ok {
+			return &t.lines[i], nil
+		}
+		return nil, fmt.Errorf("rollcall: no object at path %q on slot %d", req.Path, t.slot)
+	}
+
+	if req.Label != "" {
+		if i, ok := t.byLabel[strings.ToLower(req.Label)]; ok {
+			return &t.lines[i], nil
+		}
+		return nil, fmt.Errorf("rollcall: no object labelled %q on slot %d", req.Label, t.slot)
+	}
+
+	if req.ID != 0 {
+		if i, ok := t.byCmd[uint32(req.ID)]; ok {
+			return &t.lines[i], nil
+		}
+		// A command the menu does not list is still addressable: the device
+		// knows its own command set better than a cached walk does.
+		return &menuLine{Command: uint32(req.ID), Style: codec.StyleNumber}, nil
+	}
+
+	return nil, fmt.Errorf("rollcall: request names no object: give a path, a label or an id")
+}

--- a/internal/snell-rollcall/session/backchannel_test.go
+++ b/internal/snell-rollcall/session/backchannel_test.go
@@ -320,3 +320,91 @@ func TestFrontChannelChatterIsSurfaced(t *testing.T) {
 		t.Fatal("front-channel chatter was dropped instead of surfaced")
 	}
 }
+
+// TestPushPayloadSurvivesLaterFrames is the regression for a real defect.
+//
+// A decoded payload aliases the reader's buffer, which the next read
+// overwrites. Pushes are queued until the application takes them, so by the
+// time a listener ran, every queued push carried the bytes of whichever frame
+// arrived last. Three different values delivered as three copies of the third
+// is exactly what that looks like, and nothing about it fails loudly.
+func TestPushPayloadSurvivesLaterFrames(t *testing.T) {
+	h := newHarness(t, Config{PushQueue: 8})
+	s := h.callSession(t, codec.SvcControl)
+
+	const count = 3
+	for i := range count {
+		payload, err := codec.FuncStatus{
+			Command: 0x0113,
+			Mode:    codec.ModeValue,
+			Value:   int32(i),
+		}.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo: %v", err)
+		}
+		h.peer.push(s, codec.MsgRetFStat, payload)
+	}
+
+	// Every push is taken only after all of them have arrived, which is what
+	// the queue is for and what exposed the bug.
+	var got []int32
+	for range count {
+		select {
+		case p := <-s.Pushes():
+			fs, err := codec.DecodeFuncStatus(p.Frame.Payload)
+			if err != nil {
+				t.Fatalf("DecodeFuncStatus: %v", err)
+			}
+			got = append(got, fs.Value)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of %d pushes arrived", len(got), count)
+		}
+	}
+
+	for i, v := range got {
+		if v != int32(i) {
+			t.Errorf("push %d carries %d; the payloads were overwritten by later frames", i, v)
+		}
+	}
+}
+
+// TestUnsolicitedPayloadSurvives covers the same hazard on the other queue.
+// An announcement waits until somebody drains it, which may be long after the
+// buffer it was decoded from has been reused.
+func TestUnsolicitedPayloadSurvives(t *testing.T) {
+	h := newHarness(t, Config{})
+
+	names := []string{"Alpha", "Bravo", "Charlie"}
+	for _, name := range names {
+		payload, err := codec.DeviceInfo{ID: codec.ID{Name: name}}.AppendTo(nil)
+		if err != nil {
+			t.Fatalf("AppendTo: %v", err)
+		}
+		h.peer.write(codec.Frame{
+			Dst:     codec.Broadcast(),
+			Src:     peerAddr,
+			Type:    codec.MsgIam,
+			Payload: payload,
+		})
+	}
+
+	var got []string
+	for range names {
+		select {
+		case f := <-h.link.Unsolicited():
+			info, err := codec.DecodeDeviceInfo(f.Payload)
+			if err != nil {
+				t.Fatalf("DecodeDeviceInfo: %v", err)
+			}
+			got = append(got, info.ID.Name)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d of %d announcements arrived", len(got), len(names))
+		}
+	}
+
+	for i, name := range got {
+		if name != names[i] {
+			t.Errorf("announcement %d names %q, want %q", i, name, names[i])
+		}
+	}
+}

--- a/internal/snell-rollcall/session/link.go
+++ b/internal/snell-rollcall/session/link.go
@@ -279,6 +279,14 @@ func (l *Link) readLoop() {
 		l.rxFrames.Add(1)
 		l.resyncs.Store(r.Resyncs())
 		l.met.ObserveRx(f.Size())
+
+		// The payload aliases the reader's buffer, which the next read
+		// overwrites. Everything downstream may outlive that: a push waits in
+		// a queue until the application takes it, an announcement waits until
+		// somebody drains it, and even a reply sits in a buffered channel
+		// until its caller wakes. Copying here is what makes all of them safe
+		// at the cost of one short-lived allocation per frame.
+		f.Payload = append([]byte(nil), f.Payload...)
 		l.dispatch(f)
 	}
 }


### PR DESCRIPTION
Closes #1022. Deliverable 1 of ADR-0025. Part of #1009 (unit 5 of 10).

Stacked on #1021.

## What it does

Implements `consumer.Protocol`, registers as `rollcall`, and speaks both wire
generations on the session layer from #1019 and the spec-complete codec from
#1021.

| RollCall | dhs |
| --- | --- |
| gateway unit | Device |
| port within a unit | Slot |
| a port's type id and version | Card identity |
| menu line | Object |
| command number | Object ID |
| menu style | ValueKind and access bits |

Verbs: connect, device info, slot info, walk, get, set, set-default,
subscribe, unsubscribe, display lines, device map, port list, read file,
stream file, list directory.

## Generation negotiation

The peer advertises long strings; this connector asks for them whenever it
sees the bit, because that generation is the only one that can express a
router's command space and its menu requests are stateless.

Services are all-or-nothing, so there is no partial grant to fall back to. A
peer that advertises the bit and then refuses a call asking for it gets a
second call without it, and **the fallback is recorded as a compliance
event**: the two statements cannot both be true, and which commands are
reachable depends on which one won.

## Two protocol behaviours pinned by tests

**A container's step is a span, not a child count.** Building the tree is a
pre-order walk that consumes that many following entries. Read as a child
count, everything below the second level nests in the wrong place and the
result still looks like a tree. The test uses a menu where the two readings
put one line in different places.

**Level gating substitutes rather than removes.** A line above the session's
user level comes back as a hidden, disabled Data line named "Reserved". Line
counts are identical at every level, so a client comparing counts sees no
difference. Detected and reported.

## The file service earns its place

Two things depend on it and neither works without it. The Control Panel will
not render a device without reading `TEMPLATE.ZIP` from it, and a router
publishes every source and destination name in a file.

It opens its own session, because services are negotiated together and
all-or-nothing: asking for the file service on the control session would make
a unit that lacks one uncontrollable.

## Two defects found by the tests

**Decoded payloads aliased the reader's buffer.** Pushes wait in a queue until
the application takes them, so by the time a listener ran, every queued push
carried the bytes of whichever frame arrived last. Three different values
arrived as three copies of the third, and nothing about that fails loudly. The
link now copies each frame before dispatch; regression tests cover both the
push queue and the announcement queue.

**The file service's fields change meaning between request and reply.** The
vendor server says so outright:

```c
/* NOTE that meaning of rOffset and rExtra differs between SP_FILEREAD and SP_RETFILEREAD. */
/* - in SP_FILEREAD:    rOffset = offset into file, rExtra = number of bytes to read. */
/* - in SP_RETFILEREAD: rOffset = number of bytes actually read, rExtra = error code   */
```

And for open: `OpenModeFlags = FileSpecIn->rExtra`.

The codec had both wrong. Open flags were being sent in the offset, and the
read count was a "seek origin" that does not exist in this protocol. A read
would have asked for zero bytes every time and reported an empty file rather
than an error. Corrected, with the vendor source cited in the code, and the
open reply's block size is now honoured.

## Verification

```
ok  dhs/internal/snell-rollcall/consumer   coverage: 100.0% of statements
```

91 tests against a **fake RollCall device that speaks the wire format**, not a
mock of the session layer. A failure therefore means the bytes are wrong, not
that an expectation was written differently from the code. It runs over a pipe
with an injected clock: no socket, no port, no sleeping.

Every verb is exercised three ways: against a device that refuses it, against
one that answers with an undecodable payload, and in both generations. Five
consecutive runs, no flake.

## Coverage

**100% of statements, locked as a CI floor**, in line with every other package
in this connector.

Getting there closed twenty reachable branches and removed two duplicated
guards. The removals are the interesting half: `locate` asked for the session
after the menu walk that needs one anyway, leaving a path reachable only by a
disconnection landing between two calls; and `set16` checked whether its text
encoded after truncating that text to fit, which cannot fail and obscured the
fact that truncation is what the older generation requires.

One behaviour a new test pins: when a read reply understates how many bytes it
carries, the count is what the client believes and advances by, so the
declined byte is asked for again and the file still arrives whole. Taking the
payload while advancing by the count would duplicate a byte per block and
corrupt the middle of an archive.

## Also here

Registered in `cmd/dhs/main.go` and the frozen CLI-surface golden file updated,
which is the intended step when a protocol joins the registry:

```
+rollcall port=2050  Snell RollCall over IPShare, 16-bit and 32-bit generations
```

## Next

Unit 6, the provider, which the Control Panel already rendered once from a
throwaway spike during the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)