### PR TITLE
fix(snell-rollcall): reach every node of a real controller, ask for what it has

### DIFF
--- a/internal/snell-rollcall/codec/router/commands.go
+++ b/internal/snell-rollcall/codec/router/commands.go
@@ -15,12 +15,21 @@
 //
 // The root table is pinned by the specification, which states outright that
 // CMD_INTERFACE_VERSION is command 100 and the rest follow in order. The
-// per-matrix, per-level and per-destination tables are documented as "defined
-// in a similar fashion" with their commands listed in order but no numbers
-// given, so their offsets are read from that ordering. That reading has not yet
-// been checked against a router controller: the audit oracle answered NACK to
-// command 100, so it exposes no routing interface at all. Treat the sub-table
-// offsets as unvalidated until a real controller confirms them.
+// per-matrix, per-level and per-entity tables are documented as "defined in a
+// similar fashion", with their commands listed in order but no numbers given,
+// so their offsets were read from that ordering.
+//
+// Those offsets have since been measured against the vendor Centra controller
+// running as a Sirius 800, which serves the routing interface on its XY Panel
+// node: every command in every sub-table was read individually and its content
+// identifies which field it is, and the four table sizes here — matrix 15,
+// level 12, source 3, destination 8 — are what that controller publishes. The
+// names-file checksum below reproduces the controller's own values exactly.
+// See internal/snell-rollcall/docs/oracle-centra.md for the measurements.
+//
+// The controller advertises interface version 13; the specification copy we
+// hold documents 12. Commands are only ever added, so everything named here
+// exists, but whatever 13 introduced is not described anywhere we can read.
 //
 // This package is stdlib-only and imports nothing from dhs (ADR-0006).
 package router

--- a/internal/snell-rollcall/consumer/compliance_events.go
+++ b/internal/snell-rollcall/consumer/compliance_events.go
@@ -50,6 +50,12 @@ const (
 	// cached walk does.
 	EventUnsolicitedCommand = "rollcall_unsolicited_command"
 
+	// EventUnlistedNode means a slot was addressed that the device's own
+	// enumeration does not mention. It is addressed anyway: a gateway ages a
+	// map entry out after sixty seconds of silence, so a node missing from the
+	// list is one that has gone quiet rather than one that never existed.
+	EventUnlistedNode = "rollcall_unlisted_node"
+
 	// EventDisplayLineOutOfRange means a status line arrived for a line
 	// number outside the four the display service defines and outside the
 	// two negative priorities. It is kept under its own number.

--- a/internal/snell-rollcall/consumer/concurrency_test.go
+++ b/internal/snell-rollcall/consumer/concurrency_test.go
@@ -31,9 +31,32 @@ import (
 func TestConcurrentSessionOpenKeepsOne(t *testing.T) {
 	gate := make(chan struct{})
 	h := newHarness(t, func(d *device) {
-		d.gateCall = gate
 		d.setMenu(1, testMenu())
 	})
+
+	// Enumeration first, before the gate exists. A slot number is resolved
+	// against the device's own node list, so the session that walks it would
+	// otherwise be one of the calls the gate holds — and it would hold it
+	// forever, because nothing else can arrive until it is through.
+	if _, err := h.plugin.nodes(context.Background()); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+
+	h.device.mu.Lock()
+	h.device.gateCall = gate
+	h.device.mu.Unlock()
+
+	h.plugin.mu.RLock()
+	l0 := h.plugin.link
+	h.plugin.mu.RUnlock()
+	l0.mu.Lock()
+	before := len(l0.sessions)
+	l0.mu.Unlock()
+
+	h.device.mu.Lock()
+	deviceBefore := len(h.device.sessions)
+	h.device.callsSeen = 0
+	h.device.mu.Unlock()
 
 	// Two callers reach for port 1 together.
 	var wg sync.WaitGroup
@@ -70,29 +93,29 @@ func TestConcurrentSessionOpenKeepsOne(t *testing.T) {
 		}
 	}
 
-	// Exactly one session is kept for the port, and both callers got it.
+	// Exactly one session was added for the port, and both callers got it.
 	h.plugin.mu.RLock()
 	l := h.plugin.link
 	h.plugin.mu.RUnlock()
 
 	l.mu.Lock()
-	kept := len(l.sessions)
+	kept := len(l.sessions) - before
 	l.mu.Unlock()
 	if kept != 1 {
-		t.Errorf("the link holds %d sessions for one port, want 1", kept)
+		t.Errorf("the race added %d sessions for one port, want 1", kept)
 	}
 
 	// And the loser closed its own, so the device is not left holding two.
 	deadline = time.Now().Add(2 * time.Second)
 	for {
 		h.device.mu.Lock()
-		open := len(h.device.sessions)
+		open := len(h.device.sessions) - deviceBefore
 		h.device.mu.Unlock()
 		if open == 1 {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Errorf("the device holds %d sessions, want 1", open)
+			t.Errorf("the device kept %d of the two sessions, want 1", open)
 			break
 		}
 		time.Sleep(time.Millisecond)
@@ -332,11 +355,22 @@ func TestPumpStopsWithTheLink(t *testing.T) {
 		Payload: []byte{0x01},
 	})
 
+	// Wait for the pump to have taken both before the link dies underneath it,
+	// so this tests what the pump does with an announcement rather than which
+	// of the two goroutines won.
+	deadline := time.Now().Add(2 * time.Second)
+	for h.plugin.Announcements() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the pump absorbed %d announcements, want 2", h.plugin.Announcements())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
 	h.device.close()
 
 	// The link notices and the plugin refuses further work rather than
 	// hanging.
-	deadline := time.Now().Add(2 * time.Second)
+	deadline = time.Now().Add(2 * time.Second)
 	for {
 		if _, err := h.plugin.GetSlotInfo(context.Background(), 1); err != nil {
 			return

--- a/internal/snell-rollcall/consumer/connect.go
+++ b/internal/snell-rollcall/consumer/connect.go
@@ -26,12 +26,21 @@ type link struct {
 	gateway codec.DeviceInfo
 
 	mu       sync.Mutex
-	sessions map[uint8]*session.Session // control and menu, by port
+	// sessions are keyed by the node's whole address, not by a port: on a
+	// controller the nodes differ by unit, and keying by port would give every
+	// one of them the same session.
+	sessions map[codec.Address]*session.Session
 
 	// fileSessions are separate because services are negotiated together and
 	// all-or-nothing: asking for the file service on the control session
 	// would make a unit without one uncontrollable.
-	fileSessions map[uint8]*session.Session
+	fileSessions map[codec.Address]*session.Session
+
+	// mapSess is the one session that may ask for the device map, for the same
+	// reason. A unit answers a request belonging to a service the session did
+	// not negotiate with SP_INVSESS, not by ignoring it: measured against the
+	// vendor Centra, which refuses GETDEVLIST that way on a control session.
+	mapSess *session.Session
 
 	closed bool
 }
@@ -70,8 +79,8 @@ func (p *Plugin) Connect(ctx context.Context, ip string, port int) error {
 	l := &link{
 		sess:         sl,
 		gateway:      info,
-		sessions:     make(map[uint8]*session.Session),
-		fileSessions: make(map[uint8]*session.Session),
+		sessions:     make(map[codec.Address]*session.Session),
+		fileSessions: make(map[codec.Address]*session.Session),
 	}
 	l.keep = session.NewKeepalive(context.WithoutCancel(ctx), sl, nil)
 
@@ -133,7 +142,11 @@ func (l *link) close() {
 		return
 	}
 	l.closed = true
-	sessions := make([]*session.Session, 0, len(l.sessions)+len(l.fileSessions))
+	sessions := make([]*session.Session, 0, len(l.sessions)+len(l.fileSessions)+1)
+	if l.mapSess != nil {
+		sessions = append(sessions, l.mapSess)
+		l.mapSess = nil
+	}
 	for _, s := range l.sessions {
 		sessions = append(sessions, s)
 	}
@@ -168,28 +181,38 @@ func (p *Plugin) conn() (*link, error) {
 // requests are stateless. A peer that refuses the whole call because of that
 // bit is retried without it: services are all-or-nothing, so a partial grant
 // is not a thing that can happen.
-func (p *Plugin) session(ctx context.Context, port uint8) (*session.Session, error) {
+func (p *Plugin) session(ctx context.Context, slot int) (*session.Session, error) {
+	peer, err := p.slotAddress(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	return p.sessionAt(ctx, peer)
+}
+
+// sessionAt opens or returns the session for one node address.
+//
+// Sessions are keyed by the whole address rather than by a port, because on a
+// controller the nodes differ by unit and keying by port would hand every one
+// of them the same session.
+func (p *Plugin) sessionAt(ctx context.Context, peer codec.Address) (*session.Session, error) {
 	l, err := p.conn()
 	if err != nil {
 		return nil, err
 	}
+	peer = peer.Device()
 
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
 		return nil, consumer.ErrNotConnected
 	}
-	if s, ok := l.sessions[port]; ok {
+	if s, ok := l.sessions[peer]; ok {
 		l.mu.Unlock()
 		return s, nil
 	}
 	l.mu.Unlock()
 
-	peer := l.sess.RemoteAddress()
-	peer.Port = port
-
-	wantLong := l.gateway.ID.Services.LongStrings()
-	s, err := p.call(ctx, l, peer, wantLong)
+	s, err := p.call(ctx, l, peer, p.advertisedBy(peer, l))
 	if err != nil {
 		return nil, err
 	}
@@ -201,18 +224,99 @@ func (p *Plugin) session(ctx context.Context, port uint8) (*session.Session, err
 		return nil, consumer.ErrNotConnected
 	}
 	// Another caller may have opened one while we were waiting for the
-	// reply. Keep theirs and close ours, so a port never has two.
-	if existing, ok := l.sessions[port]; ok {
+	// reply. Keep theirs and close ours, so a node never has two.
+	if existing, ok := l.sessions[peer]; ok {
 		go func() { _ = s.Close() }()
 		return existing, nil
 	}
-	l.sessions[port] = s
+	l.sessions[peer] = s
 	return s, nil
 }
 
+// mapSession returns the session enumeration runs on.
+//
+// It asks for the map service alone. A gateway that does not advertise one is
+// asked on the control session instead, because some units answer a list on
+// any session and the walk is worth attempting before it is given up on.
+func (p *Plugin) mapSession(ctx context.Context) (*session.Session, error) {
+	l, err := p.conn()
+	if err != nil {
+		return nil, err
+	}
+	gateway := l.sess.RemoteAddress().Device()
+
+	if !l.gateway.ID.Services.Has(codec.SvcMap) {
+		return p.sessionAt(ctx, gateway)
+	}
+
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil, consumer.ErrNotConnected
+	}
+	if s := l.mapSess; s != nil {
+		l.mu.Unlock()
+		return s, nil
+	}
+	l.mu.Unlock()
+
+	// The map service is asked for on its own, without the long-string bit.
+	// What the map carries is fixed-width whichever generation is in force, so
+	// the bit buys nothing here, and the vendor Centra refuses the pair while
+	// accepting the map service alone.
+	s, err := session.Call(ctx, l.sess, gateway, codec.SvcMap, codec.LevelSupervisor, p.identity())
+	if err != nil {
+		// A gateway that will not open a map session may still answer a list
+		// on the control one. Trying is cheaper than reporting a device with
+		// no discoverable nodes.
+		p.log.Debug("rollcall: no map session; enumerating on the control session",
+			"gateway", gateway.String(), "err", err)
+		return p.sessionAt(ctx, gateway)
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		_ = s.Close()
+		return nil, consumer.ErrNotConnected
+	}
+	if existing := l.mapSess; existing != nil {
+		go func() { _ = s.Close() }()
+		return existing, nil
+	}
+	l.mapSess = s
+	return s, nil
+}
+
+// advertisedBy is what a node said it serves.
+//
+// Each node advertises for itself and they differ: on the vendor Centra the
+// matrices offer Ports and the panel node does not, and only the gateway offers
+// Map. What the enumeration said about a node is therefore better than what the
+// gateway said about itself, and the gateway's own mask is the fallback for a
+// node nothing has described.
+func (p *Plugin) advertisedBy(peer codec.Address, l *link) codec.Service {
+	p.mu.RLock()
+	t := p.nodeCache
+	p.mu.RUnlock()
+
+	if t != nil {
+		for i, addr := range t.addrs {
+			if addr.SameDevice(peer) {
+				return t.info[i].ID.Services
+			}
+		}
+	}
+	return l.gateway.ID.Services
+}
+
 // call opens one session, falling back a generation if the peer refuses.
-func (p *Plugin) call(ctx context.Context, l *link, peer codec.Address, wantLong bool) (*session.Session, error) {
-	s, err := session.Call(ctx, l.sess, peer, sessionServices(wantLong),
+func (p *Plugin) call(ctx context.Context, l *link, peer codec.Address,
+	advertised codec.Service) (*session.Session, error) {
+
+	wantLong := advertised.LongStrings()
+
+	s, err := session.Call(ctx, l.sess, peer, sessionServices(advertised, wantLong),
 		codec.LevelSupervisor, p.identity())
 	if err == nil {
 		return s, nil
@@ -227,7 +331,7 @@ func (p *Plugin) call(ctx context.Context, l *link, peer codec.Address, wantLong
 	p.fire(EventLongStringsRefused, fmt.Sprintf(
 		"%s advertises SV_LONGSTR but refused a call requesting it: %v", peer, err))
 
-	s, err = session.Call(ctx, l.sess, peer, sessionServices(false),
+	s, err = session.Call(ctx, l.sess, peer, sessionServices(advertised, false),
 		codec.LevelSupervisor, p.identity())
 	if err != nil {
 		return nil, fmt.Errorf("rollcall: call %s: %w", peer, err)
@@ -239,7 +343,7 @@ func (p *Plugin) call(ctx context.Context, l *link, peer codec.Address, wantLong
 // generation. Callers that need to know which message types will be used ask
 // this rather than inferring it from the device.
 func (p *Plugin) Uses32Bit(ctx context.Context, slot int) (bool, error) {
-	s, err := p.session(ctx, uint8(slot))
+	s, err := p.session(ctx, slot)
 	if err != nil {
 		return false, err
 	}

--- a/internal/snell-rollcall/consumer/coverage_test.go
+++ b/internal/snell-rollcall/consumer/coverage_test.go
@@ -61,7 +61,18 @@ func TestLinkClosesWhileASessionIsOpening(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gate := make(chan struct{})
-			h := newHarness(t, func(d *device) { d.gateCall = gate })
+			h := newHarness(t, nil)
+
+			// Enumerate before the gate exists. Resolving a slot number walks
+			// the device's node list, and that walk's own call would otherwise
+			// be the one the gate holds.
+			if _, err := h.plugin.nodes(context.Background()); err != nil {
+				t.Fatalf("enumerate: %v", err)
+			}
+			h.device.mu.Lock()
+			h.device.gateCall = gate
+			h.device.callsSeen = 0
+			h.device.mu.Unlock()
 
 			done := make(chan error, 1)
 			go func() { done <- tc.open(h.plugin) }()

--- a/internal/snell-rollcall/consumer/device_test.go
+++ b/internal/snell-rollcall/consumer/device_test.go
@@ -99,6 +99,10 @@ type device struct {
 	// something other than a device record, which a walker should skip.
 	oddListItem int
 
+	// refuseMap makes the device refuse a call asking for the map service,
+	// which is what a gateway that will not open one looks like.
+	refuseMap bool
+
 	// emptySlots are the ports that report nothing fitted, which is what a
 	// frame with a slot left out looks like.
 	emptySlots map[uint8]bool
@@ -142,7 +146,8 @@ type device struct {
 func newDevice(t *testing.T, conn net.Conn) *device {
 	d := &device{
 		t:             t,
-		services:      codec.SvcMenus | codec.SvcControl | codec.SvcDisplay | codec.SvcFile | codec.SvcLongStr,
+		services: codec.SvcMenus | codec.SvcControl | codec.SvcDisplay |
+			codec.SvcFile | codec.SvcMap | codec.SvcLongStr,
 		menus:         make(map[uint8][]codec.MenuItem),
 		values:        make(map[uint8]map[uint32]codec.Value),
 		files:         make(map[string][]byte),

--- a/internal/snell-rollcall/consumer/devicehandler_test.go
+++ b/internal/snell-rollcall/consumer/devicehandler_test.go
@@ -190,6 +190,11 @@ func (d *device) answerCall(f codec.Frame) {
 		d.reply(f, codec.MsgNack, []byte("no long strings\x00"))
 		return
 	}
+	if d.refuseMap && conn.Services.Has(codec.SvcMap) {
+		d.mu.Unlock()
+		d.reply(f, codec.MsgNack, append([]byte("no map service"), 0))
+		return
+	}
 	idx := d.nextIdx
 	d.nextIdx++
 	d.sessions[f.Src.Index] = f.Dst.Port
@@ -255,10 +260,15 @@ func (d *device) getStat(f codec.Frame) {
 }
 
 // deviceList answers a port enumeration with one entry per port.
+//
+// Each entry advertises what that node serves, which is what a real unit does:
+// the vendor Centra's own list gives each node its own service mask, and a
+// client uses it to decide what to ask that node for.
 func (d *device) deviceList(f codec.Frame) {
 	d.mu.Lock()
 	n := d.ports
 	odd := d.oddListItem
+	services := d.services
 	d.mu.Unlock()
 
 	d.block(f, codec.MsgGetDevList, n, func(i int) (codec.PacketType, []byte) {
@@ -269,7 +279,7 @@ func (d *device) deviceList(f codec.Frame) {
 			ProtocolVersion: codec.ProtocolVersion,
 			Address:         codec.Address{Unit: gatewayAddr.Unit, Port: uint8(i), Index: codec.IndexUnknown},
 			ID: codec.ID{
-				Services: codec.SvcMenus | codec.SvcControl,
+				Services: services,
 				TypeID:   623,
 				Name:     "Card",
 			},

--- a/internal/snell-rollcall/consumer/discover.go
+++ b/internal/snell-rollcall/consumer/discover.go
@@ -45,10 +45,11 @@ func (p *Plugin) Devices(ctx context.Context) ([]codec.DeviceInfo, error) {
 		return nil, err
 	}
 
-	// The map is fetched outside any session: it is a property of the
-	// gateway, and asking for it opens a transient session the gateway
-	// closes itself when the walk ends.
-	s, err := p.session(ctx, 0)
+	// The map service has its own session, and it is addressed to the gateway
+	// directly rather than through the slot table: the table is built from
+	// this very walk, and asking it for an address here is how a lookup
+	// becomes a loop.
+	s, err := p.mapSession(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -76,12 +77,20 @@ func (p *Plugin) Devices(ctx context.Context) ([]codec.DeviceInfo, error) {
 	return out, nil
 }
 
-// Ports returns the ports of one unit, which are its cards.
+// Ports returns what one unit enumerates: the cards in a frame's slots, or on
+// a controller the units it fronts.
 func (p *Plugin) Ports(ctx context.Context, unit uint8) ([]codec.DeviceInfo, error) {
-	s, err := p.session(ctx, 0)
+	l, err := p.conn()
 	if err != nil {
 		return nil, err
 	}
+
+	// The map session again, for the same reasons as the walk above.
+	s, err := p.mapSession(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_ = l
 
 	var out []codec.DeviceInfo
 	err = session.Walk(ctx, s, codec.MsgGetDevList, []byte{unit, 0},
@@ -108,11 +117,12 @@ func (p *Plugin) Ports(ctx context.Context, unit uint8) ([]codec.DeviceInfo, err
 // done that, and checking twice would leave a branch that cannot be reached
 // except by a disconnection landing in the gap between them.
 func (p *Plugin) slotCount(ctx context.Context, l *link) (int, error) {
-	ports, err := p.Ports(ctx, l.sess.RemoteAddress().Unit)
+	t, err := p.nodes(ctx)
 	if err != nil {
 		return 0, err
 	}
-	return len(ports), nil
+	_ = l
+	return len(t.addrs), nil
 }
 
 // GetSlotInfo returns the identity and state of one port.
@@ -125,7 +135,7 @@ func (p *Plugin) GetSlotInfo(ctx context.Context, slot int) (consumer.SlotInfo, 
 		return consumer.SlotInfo{}, fmt.Errorf("rollcall: slot %d is outside the port range", slot)
 	}
 
-	s, err := p.session(ctx, uint8(slot))
+	s, err := p.session(ctx, slot)
 	if err != nil {
 		return consumer.SlotInfo{}, err
 	}

--- a/internal/snell-rollcall/consumer/file.go
+++ b/internal/snell-rollcall/consumer/file.go
@@ -50,7 +50,7 @@ func (p *Plugin) maxFileBytes() int {
 // line endings, which corrupts an archive or a names file, and it does so
 // silently: the read succeeds and the bytes are wrong.
 func (p *Plugin) ReadFile(ctx context.Context, slot int, path string) ([]byte, error) {
-	s, err := p.fileSession(ctx, uint8(slot))
+	s, err := p.fileSession(ctx, slot)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (p *Plugin) closeFile(ctx context.Context, s *session.Session, handle int16
 
 // ListDir lists a directory on a slot.
 func (p *Plugin) ListDir(ctx context.Context, slot int, path string) ([]codec.DirEntry, error) {
-	s, err := p.fileSession(ctx, uint8(slot))
+	s, err := p.fileSession(ctx, slot)
 	if err != nil {
 		return nil, err
 	}
@@ -188,30 +188,33 @@ func (p *Plugin) ListDir(ctx context.Context, slot int, path string) ([]codec.Di
 // negotiated together and all-or-nothing: asking for the file service on the
 // control session would mean a unit without one could not be controlled at
 // all.
-func (p *Plugin) fileSession(ctx context.Context, port uint8) (*session.Session, error) {
+func (p *Plugin) fileSession(ctx context.Context, slot int) (*session.Session, error) {
+	peer, err := p.slotAddress(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+
 	l, err := p.conn()
 	if err != nil {
 		return nil, err
 	}
+	peer = peer.Device()
 
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
 		return nil, fmt.Errorf("rollcall: link closed")
 	}
-	if s, ok := l.fileSessions[port]; ok {
+	if s, ok := l.fileSessions[peer]; ok {
 		l.mu.Unlock()
 		return s, nil
 	}
 	l.mu.Unlock()
 
-	peer := l.sess.RemoteAddress()
-	peer.Port = port
-
 	s, err := session.Call(ctx, l.sess, peer, codec.SvcFile,
 		codec.LevelSupervisor, p.identity())
 	if err != nil {
-		return nil, fmt.Errorf("rollcall: file service on port %02X: %w", port, err)
+		return nil, fmt.Errorf("rollcall: file service on %s: %w", peer, err)
 	}
 
 	l.mu.Lock()
@@ -220,18 +223,18 @@ func (p *Plugin) fileSession(ctx context.Context, port uint8) (*session.Session,
 		_ = s.Close()
 		return nil, fmt.Errorf("rollcall: link closed")
 	}
-	if existing, ok := l.fileSessions[port]; ok {
+	if existing, ok := l.fileSessions[peer]; ok {
 		go func() { _ = s.Close() }()
 		return existing, nil
 	}
-	l.fileSessions[port] = s
+	l.fileSessions[peer] = s
 	return s, nil
 }
 
 // ReadFileTo streams a file into a writer, for callers that would rather not
 // hold a whole archive in memory.
 func (p *Plugin) ReadFileTo(ctx context.Context, slot int, path string, w io.Writer) (int64, error) {
-	s, err := p.fileSession(ctx, uint8(slot))
+	s, err := p.fileSession(ctx, slot)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/snell-rollcall/consumer/mapping_test.go
+++ b/internal/snell-rollcall/consumer/mapping_test.go
@@ -107,15 +107,21 @@ func TestSlotState(t *testing.T) {
 	}
 }
 
-// TestSessionServices covers what a control session asks for, and the one bit
-// that changes the answer.
+// TestSessionServices covers what a session asks a particular peer for.
+//
+// The intersection is the point: a call naming one service the peer does not
+// have is refused entirely, so a fixed mask makes a whole class of device
+// unreachable.
 func TestSessionServices(t *testing.T) {
-	short := sessionServices(false)
-	long := sessionServices(true)
+	full := codec.SvcMenus | codec.SvcControl | codec.SvcDisplay |
+		codec.SvcFile | codec.SvcMap | codec.SvcLongStr
+
+	short := sessionServices(full, false)
+	long := sessionServices(full, true)
 
 	for _, want := range []codec.Service{codec.SvcMenus, codec.SvcControl, codec.SvcDisplay} {
 		if !short.Has(want) {
-			t.Errorf("a session should ask for %s", want)
+			t.Errorf("a session should ask a device that has %s for it", want)
 		}
 	}
 	// The file service is opened separately, because services are
@@ -123,7 +129,6 @@ func TestSessionServices(t *testing.T) {
 	if short.Has(codec.SvcFile) {
 		t.Error("the control session must not ask for the file service")
 	}
-
 	if short.LongStrings() {
 		t.Error("the 16-bit request must not carry the long-string bit")
 	}
@@ -132,6 +137,35 @@ func TestSessionServices(t *testing.T) {
 	}
 	if long&^codec.SvcLongStr != short {
 		t.Error("the two requests should differ in exactly that one bit")
+	}
+
+	// The vendor Centra advertises no display service and refuses any call
+	// naming it. Asking for one anyway is how a controller becomes unreachable.
+	centra := codec.SvcMenus | codec.SvcControl | codec.SvcFile |
+		codec.SvcMap | codec.SvcLongStr
+	got := sessionServices(centra, true)
+	if got.Has(codec.SvcDisplay) {
+		t.Errorf("asked a device with no display service for one: %s", got)
+	}
+	if !got.Has(codec.SvcMenus | codec.SvcControl | codec.SvcLongStr) {
+		t.Errorf("dropped more than the display service: %s", got)
+	}
+
+	// A peer that advertises long strings and is asked for the older
+	// generation gets the older generation.
+	if sessionServices(centra, false).LongStrings() {
+		t.Error("the 16-bit request carried the long-string bit")
+	}
+	// A peer that does not advertise them is not asked for them, however much
+	// we would like the wider command space.
+	if sessionServices(codec.SvcMenus|codec.SvcControl, true).LongStrings() {
+		t.Error("asked a 16-bit peer for long strings")
+	}
+
+	// A peer whose mask says it serves none of what we want is still asked
+	// something: an empty mask asks for nothing at all and can only be refused.
+	if got := sessionServices(codec.SvcFile, true); got == 0 {
+		t.Error("an empty request is not a question")
 	}
 }
 

--- a/internal/snell-rollcall/consumer/nodes.go
+++ b/internal/snell-rollcall/consumer/nodes.go
@@ -1,0 +1,134 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// What a slot number reaches depends on what the device enumerated, and
+// assuming makes fourteen of a controller's fifteen nodes unreachable.
+//
+// A frame enumerates the ports of one unit: the cards in its slots. A router
+// controller enumerates units, each a node in its own right — the matrices, the
+// tielines engine, the panel driver that serves the routing interface — every
+// one of them at port zero. Both arrive as the same message, and only the
+// addresses inside tell them apart.
+//
+// So a slot is a position in that enumeration and its address is whatever the
+// device put there. The neutral model wants slots numbered nought upwards
+// without gaps, which is what a position gives; the protocol wants a full
+// address, which is what the entry gives. Neither has to be guessed.
+
+// nodeTable is a device's enumerated nodes, in the order it listed them.
+type nodeTable struct {
+	// addrs is the address of each slot, indexed by slot number.
+	addrs []codec.Address
+
+	// info keeps what the enumeration said about each node, so a slot read
+	// does not have to ask again for something it was already told.
+	info []codec.DeviceInfo
+}
+
+// nodes returns the device's node table, walking it once and keeping it.
+//
+// The walk is a device-list request against the gateway's own unit, which is
+// what both kinds of device answer: a frame lists its ports, a controller lists
+// the units it fronts.
+func (p *Plugin) nodes(ctx context.Context) (*nodeTable, error) {
+	l, err := p.conn()
+	if err != nil {
+		return nil, err
+	}
+
+	p.mu.RLock()
+	cached := p.nodeCache
+	p.mu.RUnlock()
+	if cached != nil {
+		return cached, nil
+	}
+
+	list, err := p.Ports(ctx, l.sess.RemoteAddress().Unit)
+	if err != nil {
+		return nil, err
+	}
+
+	t := buildNodeTable(list, l.gateway)
+
+	p.mu.Lock()
+	if p.nodeCache == nil {
+		p.nodeCache = t
+		p.log.Debug("rollcall: enumerated nodes", "count", len(t.addrs))
+	} else {
+		t = p.nodeCache
+	}
+	p.mu.Unlock()
+	return t, nil
+}
+
+// buildNodeTable turns an enumeration into a slot table.
+func buildNodeTable(list []codec.DeviceInfo, gateway codec.DeviceInfo) *nodeTable {
+	t := &nodeTable{}
+
+	if len(list) == 0 {
+		// A device that enumerated nothing still has itself, and a caller
+		// asking for slot zero must reach it rather than nothing.
+		t.addrs = []codec.Address{gateway.Address.Device()}
+		t.info = []codec.DeviceInfo{gateway}
+		return t
+	}
+
+	for _, d := range list {
+		t.addrs = append(t.addrs, d.Address.Device())
+		t.info = append(t.info, d)
+	}
+	return t
+}
+
+// address returns the address that reaches a slot, and whether the enumeration
+// named it.
+func (t *nodeTable) address(slot int) (codec.Address, bool) {
+	if slot < 0 || slot >= len(t.addrs) {
+		return codec.Address{}, false
+	}
+	return t.addrs[slot], true
+}
+
+// slotAddress resolves a slot number to the address that reaches it.
+//
+// A slot past the end of the enumeration is still addressed rather than
+// refused: a gateway ages a map entry out after sixty seconds of silence, so a
+// node missing from the list is one that has gone quiet rather than one that
+// never existed, and a caller that knows the port number is entitled to try.
+func (p *Plugin) slotAddress(ctx context.Context, slot int) (codec.Address, error) {
+	if slot < 0 || slot > 0xFF {
+		return codec.Address{}, fmt.Errorf("rollcall: slot %d is outside the address range", slot)
+	}
+
+	l, err := p.conn()
+	if err != nil {
+		return codec.Address{}, err
+	}
+	fallback := l.sess.RemoteAddress().Device()
+	fallback.Port = uint8(slot)
+
+	t, err := p.nodes(ctx)
+	if err != nil {
+		// Enumeration is a convenience, not a precondition: a device that will
+		// not list its nodes can still be addressed by the port number a
+		// caller already knows.
+		p.log.Debug("rollcall: could not enumerate nodes; addressing by port",
+			"slot", slot, "err", err)
+		return fallback, nil
+	}
+
+	addr, ok := t.address(slot)
+	if !ok {
+		p.fire(EventUnlistedNode, fmt.Sprintf(
+			"slot %d is past the %d the device listed; addressing it as %s",
+			slot, len(t.addrs), fallback))
+		return fallback, nil
+	}
+	return addr, nil
+}

--- a/internal/snell-rollcall/consumer/nodes_test.go
+++ b/internal/snell-rollcall/consumer/nodes_test.go
@@ -1,0 +1,351 @@
+package rollcall
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/session"
+)
+
+// A slot number reaches whatever the device enumerated at that position. These
+// cover both shapes: a frame that lists the ports of one unit, and a controller
+// that lists units, which is what the vendor Centra does and what made fourteen
+// of its fifteen nodes unreachable before.
+
+func TestNodeTableFromAFrame(t *testing.T) {
+	list := []codec.DeviceInfo{
+		{Address: codec.Address{Unit: 8, Port: 0, Index: codec.IndexUnknown}},
+		{Address: codec.Address{Unit: 8, Port: 1, Index: codec.IndexUnknown}},
+		{Address: codec.Address{Unit: 8, Port: 2, Index: codec.IndexUnknown}},
+	}
+	tbl := buildNodeTable(list, codec.DeviceInfo{})
+
+	if len(tbl.addrs) != 3 {
+		t.Fatalf("%d slots, want 3", len(tbl.addrs))
+	}
+	for slot, want := range []uint8{0, 1, 2} {
+		addr, ok := tbl.address(slot)
+		if !ok {
+			t.Fatalf("slot %d is missing", slot)
+		}
+		if addr.Unit != 8 || addr.Port != want {
+			t.Errorf("slot %d = %s, want unit 08 port %02X", slot, addr, want)
+		}
+	}
+}
+
+func TestNodeTableFromAController(t *testing.T) {
+	// The shape the vendor Centra enumerates: nodes at port zero of their own
+	// units. Addressing these by port would send every one of them to the same
+	// place.
+	list := []codec.DeviceInfo{
+		{Address: codec.Address{Unit: 0x08, Index: codec.IndexUnknown},
+			ID: codec.ID{Name: "Nucleus 2"}},
+		{Address: codec.Address{Unit: 0x11, Index: codec.IndexUnknown},
+			ID: codec.ID{Name: "Matrix 1"}},
+		{Address: codec.Address{Unit: 0x81, Index: codec.IndexUnknown},
+			ID: codec.ID{Name: "XY Panel"}},
+	}
+	tbl := buildNodeTable(list, codec.DeviceInfo{})
+
+	for slot, want := range []uint8{0x08, 0x11, 0x81} {
+		addr, ok := tbl.address(slot)
+		if !ok {
+			t.Fatalf("slot %d is missing", slot)
+		}
+		if addr.Unit != want || addr.Port != 0 {
+			t.Errorf("slot %d = %s, want unit %02X port 00", slot, addr, want)
+		}
+	}
+	if tbl.info[2].ID.Name != "XY Panel" {
+		t.Errorf("slot 2 described as %q", tbl.info[2].ID.Name)
+	}
+}
+
+func TestNodeTableOfADeviceThatListsNothing(t *testing.T) {
+	gateway := codec.DeviceInfo{
+		Address: codec.Address{Unit: 4, Port: 7, Index: codec.IndexUnknown},
+		ID:      codec.ID{Name: "alone"},
+	}
+	tbl := buildNodeTable(nil, gateway)
+
+	// A device that enumerated nothing still has itself, and a caller asking
+	// for slot zero must reach it rather than nothing.
+	addr, ok := tbl.address(0)
+	if !ok {
+		t.Fatal("the device is not in its own table")
+	}
+	if addr.Unit != 4 || addr.Port != 7 {
+		t.Errorf("slot 0 = %s, want the gateway's own address", addr)
+	}
+	if _, ok := tbl.address(1); ok {
+		t.Error("a table of one has a second slot")
+	}
+	if _, ok := tbl.address(-1); ok {
+		t.Error("a negative slot resolved")
+	}
+}
+
+func TestSlotAddressUsesTheEnumeration(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 3 })
+
+	for slot, want := range []uint8{0, 1, 2} {
+		addr, err := h.plugin.slotAddress(context.Background(), slot)
+		if err != nil {
+			t.Fatalf("slot %d: %v", slot, err)
+		}
+		if addr.Port != want || addr.Unit != gatewayAddr.Unit {
+			t.Errorf("slot %d = %s", slot, addr)
+		}
+	}
+}
+
+func TestSlotAddressPastTheEnumeration(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 2 })
+
+	// A gateway ages a map entry out after sixty seconds of silence, so a slot
+	// missing from the list is one that has gone quiet. A caller that knows
+	// the port number is entitled to try it.
+	addr, err := h.plugin.slotAddress(context.Background(), 9)
+	if err != nil {
+		t.Fatalf("slot 9: %v", err)
+	}
+	if addr.Port != 9 {
+		t.Errorf("slot 9 = %s, want port 09", addr)
+	}
+	if !hasEvent(h.plugin, EventUnlistedNode) {
+		t.Error("addressing an unlisted node should be recorded")
+	}
+}
+
+func TestSlotAddressOutsideTheAddressRange(t *testing.T) {
+	h := newHarness(t, nil)
+
+	for _, slot := range []int{-1, 256} {
+		if _, err := h.plugin.slotAddress(context.Background(), slot); err == nil {
+			t.Errorf("slot %d should not be addressable", slot)
+		}
+	}
+}
+
+func TestSlotAddressWithoutAnEnumeration(t *testing.T) {
+	// A device that will not list its nodes is still usable: the slot number
+	// is taken as a port on the gateway's own unit, which is what it meant
+	// before anything enumerated anything.
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetDevList] = true })
+
+	addr, err := h.plugin.slotAddress(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("slot 3: %v", err)
+	}
+	if addr.Port != 3 || addr.Unit != gatewayAddr.Unit {
+		t.Errorf("slot 3 = %s, want port 03 on the gateway", addr)
+	}
+}
+
+func TestTheEnumerationIsWalkedOnce(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 3 })
+
+	first, err := h.plugin.nodes(context.Background())
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := h.plugin.nodes(context.Background())
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	// Walking it again would cost a round trip per slot on every call, and the
+	// list only changes when a unit comes or goes.
+	if first != second {
+		t.Error("the node table was rebuilt")
+	}
+}
+
+func TestTheMapSessionIsSeparateAndReused(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 2 })
+
+	first, err := h.plugin.mapSession(context.Background())
+	if err != nil {
+		t.Fatalf("map session: %v", err)
+	}
+	second, err := h.plugin.mapSession(context.Background())
+	if err != nil {
+		t.Fatalf("map session again: %v", err)
+	}
+	if first != second {
+		t.Error("a second map session was opened")
+	}
+
+	// It is not the control session: services are negotiated together and a
+	// unit answers a request outside its session's services with InvSess.
+	control, err := h.plugin.session(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("control session: %v", err)
+	}
+	if control == first {
+		t.Error("the map walk shares the control session")
+	}
+	if !first.Services().Has(codec.SvcMap) {
+		t.Errorf("the map session negotiated %s", first.Services())
+	}
+	// Asking for the map service alone: the long-string bit buys nothing on a
+	// fixed-width structure, and the vendor Centra refuses the pair.
+	if first.Services().LongStrings() {
+		t.Errorf("the map session asked for long strings: %s", first.Services())
+	}
+}
+
+func TestAGatewayThatRefusesAMapSession(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuseMap = true })
+
+	// Some units answer a list on any session, so the walk is worth attempting
+	// on the control one rather than reporting a device with no nodes.
+	s, err := h.plugin.mapSession(context.Background())
+	if err != nil {
+		t.Fatalf("map session: %v", err)
+	}
+	if s.Services().Has(codec.SvcMap) {
+		t.Error("the fallback session claimed the map service")
+	}
+
+	if _, err := h.plugin.nodes(context.Background()); err != nil {
+		t.Errorf("enumeration should still have worked: %v", err)
+	}
+}
+
+func TestAGatewayWithNoMapServiceUsesTheControlSession(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.services = codec.SvcMenus | codec.SvcControl | codec.SvcLongStr
+	})
+
+	s, err := h.plugin.mapSession(context.Background())
+	if err != nil {
+		t.Fatalf("map session: %v", err)
+	}
+	control, err := h.plugin.session(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("control session: %v", err)
+	}
+	if s != control {
+		t.Error("a gateway with no map service should be asked on its control session")
+	}
+}
+
+func TestServicesComeFromTheNodeThatAdvertisedThem(t *testing.T) {
+	// Each node advertises for itself, and they differ: on the vendor Centra
+	// the matrices offer Ports and the panel node does not. What the
+	// enumeration said about a node beats what the gateway said about itself.
+	h := newHarness(t, func(d *device) { d.ports = 2 })
+
+	if _, err := h.plugin.nodes(context.Background()); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+
+	listed := codec.Address{Unit: gatewayAddr.Unit, Port: 1, Index: codec.IndexUnknown}
+	if got := h.plugin.advertisedBy(listed, l); got == 0 {
+		t.Error("a listed node has no advertised services")
+	}
+
+	// A node nothing described falls back to what the gateway advertised,
+	// which is the only statement anybody has made about it.
+	unlisted := codec.Address{Unit: 0x77, Index: codec.IndexUnknown}
+	if got := h.plugin.advertisedBy(unlisted, l); got != l.gateway.ID.Services {
+		t.Errorf("an unlisted node advertised %s, want the gateway's %s",
+			got, l.gateway.ID.Services)
+	}
+}
+
+func TestEnumerationWithoutAConnection(t *testing.T) {
+	p := New(testDeps())
+
+	if _, err := p.nodes(context.Background()); err == nil {
+		t.Error("enumerating without a connection should fail")
+	}
+	if _, err := p.mapSession(context.Background()); err == nil {
+		t.Error("opening a map session without a connection should fail")
+	}
+	if _, err := p.slotAddress(context.Background(), 1); err == nil {
+		t.Error("resolving a slot without a connection should fail")
+	}
+}
+
+func TestTheLinkClosesWhileTheMapSessionIsOpening(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, func(d *device) { d.gateCall = gate })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := h.plugin.mapSession(context.Background())
+		done <- err
+	}()
+
+	waitForCalls(t, h, 1)
+
+	// Finished with, without closing the socket, so the call still completes
+	// and the answer still arrives. The session the peer just granted has to
+	// be closed rather than handed out.
+	h.plugin.mu.RLock()
+	l := h.plugin.link
+	h.plugin.mu.RUnlock()
+	l.mu.Lock()
+	l.closed = true
+	l.mu.Unlock()
+
+	close(gate)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("a map session granted after the link finished must not be handed out")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the caller was left waiting")
+	}
+}
+
+func TestConcurrentFileSessionsKeepOne(t *testing.T) {
+	gate := make(chan struct{})
+	h := newHarness(t, nil)
+
+	// Enumeration first: resolving the slot walks the node list, and that
+	// walk's own call would otherwise be one of the racing pair.
+	if _, err := h.plugin.nodes(context.Background()); err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.gateCall = gate
+	h.device.callsSeen = 0
+	h.device.mu.Unlock()
+
+	var wg sync.WaitGroup
+	results := make([]*session.Session, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s, err := h.plugin.fileSession(context.Background(), 1)
+			if err != nil {
+				t.Errorf("caller %d: %v", i, err)
+				return
+			}
+			results[i] = s
+		}()
+	}
+
+	waitForCalls(t, h, 2)
+	close(gate)
+	wg.Wait()
+
+	// A file service costs a session like any other, and a unit that runs out
+	// stops answering anybody: the loser closes its own and takes the winner's.
+	if results[0] != results[1] {
+		t.Error("two callers were given two file sessions for one slot")
+	}
+}

--- a/internal/snell-rollcall/consumer/plugin.go
+++ b/internal/snell-rollcall/consumer/plugin.go
@@ -31,6 +31,7 @@ package rollcall
 import (
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"dhs/internal/clock"
 	"dhs/internal/consumer"
@@ -101,6 +102,11 @@ type Plugin struct {
 	// path resolvable without walking again.
 	trees map[int]*slotTree
 
+	// nodeCache is the device's enumerated nodes, walked once per connection.
+	// It is what turns a slot number into an address, and a controller's nodes
+	// are unreachable without it.
+	nodeCache *nodeTable
+
 	subs map[subKey]consumer.EventFunc
 
 	// comp collects spec deviations. The connector absorbs each one and keeps
@@ -116,7 +122,16 @@ type Plugin struct {
 	// addr is what we were asked to connect to, kept for DeviceInfo.
 	addr string
 	port int
+
+	// announcements counts the units that have announced themselves on this
+	// link. A device that has gone quiet is the usual explanation for a node
+	// missing from a gateway's map, so the count is worth having.
+	announcements atomic.Uint64
 }
+
+// Announcements returns how many unit announcements this connector has
+// absorbed since it connected.
+func (p *Plugin) Announcements() uint64 { return p.announcements.Load() }
 
 // subKey identifies a subscription. A zero command means every command on the
 // slot, which is what an empty label or id in the request asks for.
@@ -188,14 +203,31 @@ func styleAccess(style codec.Style) uint8 {
 	}
 }
 
-// sessionServices is what a control-and-menu session asks for.
+// wantedServices is what a control-and-menu session would like.
 //
 // Display is included because a unit's status lines are pushed on the same
-// session, and asking for it later would mean a second call. File is not:
-// it is opened on demand, so a unit without a file service is still usable.
-func sessionServices(longStrings bool) codec.Service {
-	s := codec.SvcMenus | codec.SvcControl | codec.SvcDisplay
-	if longStrings {
+// session, and asking for it later would mean a second call. File is not: it is
+// opened on demand, so a unit without a file service is still usable.
+const wantedServices = codec.SvcMenus | codec.SvcControl | codec.SvcDisplay
+
+// sessionServices is what to ask a particular peer for.
+//
+// It is the intersection of what we want with what the peer advertised, and
+// the intersection is not optional. Services are all-or-nothing: a call that
+// names one service the peer does not have is refused entirely, so asking a
+// controller with no display service for a display makes the whole device
+// unreachable. Measured against the vendor Centra, which refuses every call
+// naming SV_DISPLAY and accepts the identical call without it.
+func sessionServices(advertised codec.Service, longStrings bool) codec.Service {
+	s := wantedServices & advertised
+	if s == 0 {
+		// A peer that advertised none of them is either wrong about itself or
+		// serving something we do not know about. Ask for the pair every unit
+		// has and let it answer for itself, rather than sending an empty mask
+		// that asks for nothing at all.
+		s = codec.SvcMenus | codec.SvcControl
+	}
+	if longStrings && advertised.LongStrings() {
 		s |= codec.SvcLongStr
 	}
 	return s
@@ -204,5 +236,5 @@ func sessionServices(longStrings bool) codec.Service {
 // identity is what we present to a peer. The name is what appears in the
 // vendor's own session list, so it says what we are.
 func (p *Plugin) identity() codec.DeviceInfo {
-	return session.ClientIdentity("dhs rollcall", sessionServices(true))
+	return session.ClientIdentity("dhs rollcall", wantedServices|codec.SvcLongStr)
 }

--- a/internal/snell-rollcall/consumer/subscribe.go
+++ b/internal/snell-rollcall/consumer/subscribe.go
@@ -26,7 +26,7 @@ func (p *Plugin) Subscribe(req consumer.ValueRequest, fn consumer.EventFunc) err
 	}
 
 	ctx := context.Background()
-	s, err := p.session(ctx, uint8(req.Slot))
+	s, err := p.session(ctx, req.Slot)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (p *Plugin) Unsubscribe(req consumer.ValueRequest) error {
 		return nil
 	}
 
-	s, err := p.session(ctx, uint8(req.Slot))
+	s, err := p.session(ctx, req.Slot)
 	if err != nil {
 		// Nothing left to tell; the subscription is gone either way.
 		return nil //nolint:nilerr // an unreachable device needs no unsubscribe
@@ -306,6 +306,7 @@ func (p *Plugin) pumpBackChannel() {
 			return
 		case f := <-l.sess.Unsolicited():
 			if f.Type == codec.MsgIam {
+				p.announcements.Add(1)
 				if info, err := codec.DecodeDeviceInfo(f.Payload); err == nil {
 					p.log.Debug("rollcall: announcement",
 						"unit", info.Address.String(),

--- a/internal/snell-rollcall/consumer/value.go
+++ b/internal/snell-rollcall/consumer/value.go
@@ -161,7 +161,7 @@ func (p *Plugin) SetDefault(ctx context.Context, req consumer.ValueRequest) (con
 // landing in the gap between the two calls, which is a branch nothing can
 // exercise and nobody can reason about.
 func (p *Plugin) locate(ctx context.Context, req consumer.ValueRequest) (*menuLine, *session.Session, error) {
-	s, err := p.session(ctx, uint8(req.Slot))
+	s, err := p.session(ctx, req.Slot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,7 +274,7 @@ func (p *Plugin) encodeValue(line *menuLine, val consumer.Value) (codec.Mode, in
 // and a warning. That is why they have their own accessor rather than
 // appearing in a walk.
 func (p *Plugin) Display(ctx context.Context, slot int) (map[int16]string, error) {
-	s, err := p.session(ctx, uint8(slot))
+	s, err := p.session(ctx, slot)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/snell-rollcall/consumer/walk.go
+++ b/internal/snell-rollcall/consumer/walk.go
@@ -74,7 +74,7 @@ func (p *Plugin) walkTree(ctx context.Context, slot int) (*slotTree, error) {
 		return nil, fmt.Errorf("rollcall: slot %d is outside the port range", slot)
 	}
 
-	s, err := p.session(ctx, uint8(slot))
+	s, err := p.session(ctx, slot)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/snell-rollcall/docs/oracle-centra.md
+++ b/internal/snell-rollcall/docs/oracle-centra.md
@@ -1,0 +1,299 @@
+# Oracle run: the vendor Centra controller
+
+What a real Snell router controller does on the wire, measured rather than
+read. Every claim below was produced by driving
+`assets/Emulator/RouterSimulator/Router2.zip` — the vendor's own
+`CentraController.exe`, run as a Sirius 800
+(`CENTRA_SIMULATED_ROUTER=3`) — with our own session layer.
+
+This matters because the Full Control Command Set document lists the
+per-matrix, per-level and per-entity commands "in a similar fashion" without
+giving their numbers. Until this run, `codec/router` read those offsets out of
+the order the document lists them in and said so in its package comment. They
+are now measured.
+
+Date: 2026-09-07. Controller: `Nucleus 2`, RollCall version 3.0 cs12,
+IPShare port 2057.
+
+---
+
+## 1. A router is a different unit, not a port
+
+The gateway answers as `0000-08-00`. Its device map lists fifteen nodes, and
+they differ by **unit**, not by port:
+
+| Address | Name | Type | Services |
+|---|---|---|---|
+| `0000-08-00` | `<not set>` | Nucleus 2 | Menus, Control, File, Map, LongStr |
+| `0000-11-00` | Matrix 1 | Router Matrix | Menus, Control, File, Ports, LongStr |
+| `0000-12-00` | Matrix 2 | Router Matrix | Menus, Control, File, Ports, LongStr |
+| `0000-41-00` … `0000-44-00` | input cards | 5915, 5919, 4915 MADI, 4915 AES | … |
+| `0000-61-00` … `0000-66-00` | output cards | 5925, 5949, 4929 MADI/AES, 4925 MADI/AES | … |
+| `0000-80-00` | TIELINES | TIELINES | Menus, Control, File, LongStr |
+| `0000-81-00` | XY Panel | XY Panel | Menus, Control, File, LongStr |
+
+Consequences:
+
+- A client that addresses only ports on the gateway's own unit sees one node
+  and misses the other fourteen. Discovery has to walk the device map and
+  address each node by its **unit**.
+- An absent port is **not refused**: the controller says nothing at all, and
+  the client waits out its own timeout. Our provider Nacks instead, which is
+  friendlier and equally legal, but a client must not assume a reply.
+
+## 2. The routing interface is on the XY Panel node
+
+Command 100 answers on `0000-81-00` and is refused everywhere else:
+
+| Node | Command 100 |
+|---|---|
+| XY Panel (`0x81`) | `13` — the interface version |
+| Matrix 1 / Matrix 2 (`0x11`, `0x12`) | NACK, logged by the controller as `FCSendRetValue: WARNING - command not valid` |
+| TIELINES (`0x80`) | answers 0 for commands 100–103, NACK above |
+| Nucleus (`0x08`) | NACK |
+
+This is what the design document means by connecting to the *PanelDevice*
+rather than the RouterDevice. The Matrix nodes are the hardware; the panel node
+is the routing interface. Probing command 100 on every node in the map is how a
+client finds it, and the Matrix nodes' polite refusal is what makes that safe.
+
+**Interface version 13** is one past the last revision our specification copy
+documents (12, "updated error codes returned when making a route"). Commands
+are only ever added, so everything documented is present; whatever 13 added is
+not in the document we hold.
+
+## 3. The root table, measured
+
+| Command | Name | Value |
+|---|---|---|
+| 100 | `CMD_INTERFACE_VERSION` | 13 |
+| 101 | `CMD_ROUTER_NAME` | `"<not set>"` |
+| 102 | `CMD_NUM_MATRICES` | 2 |
+| 103 | `CMD_MATRIX_BASE` | 121 |
+| 104 | `CMD_MATRIX_STEP` | 15 |
+| 105 | `CMD_NUM_CATEGORIES` | 0 |
+| 106 | `CMD_CATEGORY_BASE` | 151 |
+| 107 | `CMD_CATEGORY_STEP` | 6 |
+| 113 | `CMD_NUM_SALVOS` | 4 |
+| 117 | `CMD_NUM_DEVICES` | 100 |
+
+`CategoryBase = MatrixBase + NumMatrices × MatrixStep` — 151 = 121 + 2 × 15 —
+which is the arithmetic the whole command space is built from, confirmed by the
+controller's own numbering.
+
+## 4. Every sub-table offset, measured
+
+Matrix 1's table at base 121, step 15. Each command was read individually and
+its content identifies which field it is:
+
+| Offset | Command | Name | Value read |
+|---:|---:|---|---|
+| 0 | 121 | `CMD_MATRIX_NAME` | `"R1 Matrix 1"` |
+| 1 | 122 | `CMD_NUM_LEVELS` | 2 |
+| 2 | 123 | `CMD_LEVEL_BASE` | 151 |
+| 3 | 124 | `CMD_LEVEL_STEP` | 12 |
+| 4 | 125 | `CMD_NUM_SRC_ASSOCS` | 10 |
+| 5 | 126 | `CMD_SRC_ASSOC_BASE` | 175 |
+| 6 | 127 | `CMD_SRC_ASSOC_STEP` | 5 |
+| 7 | 128 | `CMD_NUM_DST_ASSOCS` | 10 |
+| 8 | 129 | `CMD_DST_ASSOC_BASE` | 225 |
+| 9 | 130 | `CMD_DST_ASSOC_STEP` | 5 |
+| 10 | 131 | `CMD_ASSOC_NAMES_8_FILENAME` | `RC_Files\AssocNames_1_8.dat` + CRC |
+| 11 | 132 | `CMD_ASSOC_NAMES_32_FILENAME` | `RC_Files\AssocNames_1_32.dat` + CRC |
+| 12 | 133 | `CMD_ASSOC_NAMES_ALT_FILENAME` | `RC_Files\AssocNames_1_alt.dat` + CRC |
+| 13 | 134 | `CMD_CONTROLLER_NUMBER` | 1 |
+| 14 | 135 | `CMD_ASSOC_MAPPINGS_FILENAME` | `RC_Files\AssocMap_1.dat` + CRC |
+
+Level 1 of matrix 1, base 151, step 12:
+
+| Offset | Command | Name | Value read |
+|---:|---:|---|---|
+| 0 | 151 | `CMD_LEVEL_NAME` | `"R1M1 Level 1"` |
+| 1 | 152 | `CMD_LEVEL_TYPE` | 0 |
+| 2 | 153 | `CMD_NUM_SRCS` | 10 |
+| 3 | 154 | `CMD_SRC_BASE` | 275 |
+| 4 | 155 | `CMD_SRC_STEP` | 3 |
+| 5 | 156 | `CMD_NUM_DSTS` | 10 |
+| 6 | 157 | `CMD_DST_BASE` | 305 |
+| 7 | 158 | `CMD_DST_STEP` | 8 |
+| 8 | 159 | `CMD_SRCDST_NAMES_8_FILENAME` | `RC_Files\SrcDstNames_1_1_8.dat` + CRC |
+| 9 | 160 | `CMD_SRCDST_NAMES_32_FILENAME` | `…_1_1_32.dat` + CRC |
+| 10 | 161 | `CMD_SRCDST_NAMES_ALT_FILENAME` | `…_1_1_alt.dat` + CRC |
+| 11 | 162 | `CMD_SRCDST_MC_DATA_FILENAME` | `RC_Files\SrcDstMCData_1_1.dat` + CRC |
+
+Source 1 of that level, base 275, step 3:
+
+| Offset | Command | Name | Value read |
+|---:|---:|---|---|
+| 0 | 275 | `CMD_SRC_NAME_8` | `"R1M1L1S1"` |
+| 1 | 276 | `CMD_SRC_NAME_32` | `"mtx01src000001"` |
+| 2 | 277 | `CMD_SRC_ALT_NAME` | `"alt01l001s00001"` |
+
+Destination 1 of that level, base 305, step 8:
+
+| Offset | Command | Name | Value read |
+|---:|---:|---|---|
+| 0 | 305 | `CMD_DEST_NAME_8` | `"R1M1L1D1"` |
+| 1 | 306 | `CMD_DEST_NAME_32` | `"mtx01dst000001"` |
+| 2 | 307 | `CMD_DEST_ALT_NAME` | `"alt01l001s00001"` |
+| 3 | 308 | `CMD_DEST_ROUTED_SRC` | DTP `[uint 0x01010001]` |
+| 4 | 309 | `CMD_DEST_PROTECT_STATE` | mode `VALUE\|STRING`, 0, `""` |
+| 5 | 310 | `CMD_DEST_MC_SRCS_ROUTED` | DTP, empty |
+| 6 | 311 | `CMD_DEST_MC_PROTECTS` | DTP, empty |
+| 7 | 312 | `CMD_DEST_MC_PROTECTED` | DTP, empty |
+
+Level 2 of matrix 1 continues at 163, which is 151 + 12: the level step the
+controller published. Sources for level 2 start at 385, destinations at 415.
+
+**All four table sizes in `codec/router` are confirmed**: matrix 15, level 12,
+source 3, destination 8.
+
+## 5. The names-file checksum is confirmed exactly
+
+The controller publishes a filename and a CRC as Data Transfer Params, e.g.
+command 131 returns
+
+```
+02 06 1b "RC_Files\AssocNames_1_8.dat" 05 88 ac 9e b3 0e
+```
+
+— two items: a string, then a uint. Computing `NamesFile.CRC()` over the
+matching file from the simulator's own `RC_Files` directory reproduces the
+controller's value in every case:
+
+| File | Controller | Computed |
+|---|---|---|
+| `AssocNames_1_8.dat` | `0xE6679608` | `0xE6679608` |
+| `AssocNames_1_32.dat` | `0x673356C4` | `0x673356C4` |
+| `AssocMap_1.dat` | `0x5C2378A6` | `0x5C2378A6` |
+
+So the rule the specification describes — each name hashed with IEEE CRC-32
+over its padded field followed by its zero-based index as a little-endian
+uint32, and those hashes summed with 32-bit wrapping — is what the controller
+actually does. A client can trust a cached names file whose checksum matches
+and skip the fetch.
+
+The file layouts decode too: names files are fixed-width, sources then
+destinations, no header; association mappings are one 32-bit entry per level
+per association; the multi-channel file is the variable-length record the
+document describes.
+
+## 6. Making a route
+
+Reading `CMD_DEST_ROUTED_SRC` returns DTP with one uint: the source pin, packed
+`matrix<<24 | level<<16 | source`. Setting it takes DTP with a uint **array**
+of one or two entries — the pin, and optionally a protect id.
+
+Measured sequence, destination 1 of matrix 1 level 1:
+
+```
+read           dtp=[uint 0x01010001]              m1/l1/s1
+set  s3        reply dtp=[uint 0x01010001, uint 0]  ← the value BEFORE the set, and result 0
+               push  RETVALUE cmd=308 dtp=[uint 0x01010003]
+read           dtp=[uint 0x01010003]              m1/l1/s3
+```
+
+Two things a client must get right:
+
+- **The reply to a set carries the previous value.** The result code is
+  appended and is 0 for success, but the pin in that reply is what was routed
+  before. The new value arrives on the back channel as a `SP_RETVALUE` push for
+  the same command. A client that trusts the reply's pin shows a stale
+  crosspoint until something else refreshes it.
+- **The tally follows tielines.** Setting source 7 on this configuration reads
+  back as `0x02010001` — matrix 2, level 1, source 1 — because the route was
+  completed through a tieline and the pin reports the final upstream source,
+  exactly as the document says. A client that expects to read back what it
+  wrote is wrong about this protocol, not about the router.
+
+## 7. Sessions and services
+
+The gateway advertises `Menus|Control|File|Map|LongStr`. Measured, one call per
+fresh connection:
+
+| Requested | Result |
+|---|---|
+| `Menus` / `Control` / `File` / `Map`, each alone | accepted |
+| `Menus\|Control` | accepted, 16-bit |
+| `Menus\|Control\|LongStr` | accepted, 32-bit |
+| `Menus\|Control\|File\|Map\|LongStr` | accepted, 32-bit |
+| anything including `Display` | **refused** |
+
+So a subset is fine — services are all-or-nothing in the sense that the server
+grants all of what was asked or none of it, not in the sense that a client must
+ask for everything. What a client may not do is ask for a service the peer does
+not advertise: this controller has no Display service and refuses the call
+outright. The refusal was bracketed by the identical call without `Display`
+succeeding immediately before and after it, so it is the service and not the
+controller's mood.
+
+That is the whole reason `dhs consumer rollcall info` could not talk to this
+controller: the consumer asked for a fixed set including `Display`.
+
+**A NACK to a Call is not necessarily about the mask.** During this run the
+controller went through a phase of refusing every call, including ones it had
+just accepted, and recovered on its own. Forty sessions opened on one link
+without complaint, so it is not a small pool; whatever the cause, a client must
+treat a refused call as worth retrying rather than as proof that a service is
+missing. Note also that this controller answers a call it cannot satisfy with
+`SP_NACK` rather than `SP_BUSY`, which is what the specification provides for
+exactly this.
+
+A request belonging to a service the session did not negotiate is answered
+`SP_INVSESS`: walking the device map on a session opened for `Menus|Control`
+fails that way rather than with a NACK. Our provider Nacks in the same
+situation. Both are defensible; the vendor's is more precise.
+
+## 8. What this changed in our code
+
+- `codec/router`'s package comment no longer says the sub-table offsets are
+  unvalidated, because they are not.
+- **The consumer asked every peer for a fixed service set including Display.**
+  This controller has no display service and refuses the whole call, so
+  `dhs consumer rollcall info` could not open a session against it at all. The
+  mask is now the intersection of what we want with what the peer advertised,
+  taken per node: each entry in the device list carries its own services, and
+  they differ between the matrices, the panel node and the gateway.
+- **The consumer addressed a slot as a port on the gateway's own unit.** On
+  this controller the nodes differ by unit, so fourteen of the fifteen were
+  unreachable and reading one timed out rather than failing. A slot is now a
+  position in the device's own enumeration and its address is whatever the
+  device put there — a port on a frame, a unit on a controller — with the
+  address reported in the slot's identity so an operator can see which node a
+  number reached.
+- **The device map has its own session.** A request belonging to a service the
+  session did not negotiate is answered `SP_INVSESS`, so enumerating on the
+  control session failed. The map service is asked for on its own and without
+  the long-string bit, which this controller refuses in that combination; a
+  gateway that will not open one is asked on the control session instead,
+  because some units answer a list on any session.
+
+After those three, every node of the controller is reachable from the command
+line:
+
+```
+$ dhs consumer rollcall info 127.0.0.1:2057
+slots        15
+  slot  0   status=present    online=true
+  …
+  slot 14   status=present    online=true
+
+$ dhs consumer rollcall walk 127.0.0.1:2057 --slot 14
+slot 14 — 3 objects
+```
+
+Three objects, because slot 14 is the XY Panel: a router node serves its
+routing and its names as control variables, not as menu lines, which is exactly
+what the design document says and why a menu walk finds almost nothing there.
+
+## 9. Reproducing it
+
+```
+# Unpack the vendor simulator somewhere writable and run it as a Sirius 800.
+CENTRA_SIMULATED_ROUTER=3 CentraController.exe        # RollCall IPShare on 2057
+dhs consumer rollcall info 127.0.0.1:2057
+```
+
+The simulator writes `FCSendRetValue: WARNING - command not valid` to stdout
+for every routing command it refuses, which is a useful confirmation that a
+NACK came from the Full Control layer rather than from the session layer.


### PR DESCRIPTION
Closes #1026. Stacked on #1025.

Found by running the vendor Centra controller — `assets/Emulator/RouterSimulator/Router2.zip`,
`CentraController.exe` as a **Sirius 800** — and pointing our own consumer at
it. Measurements: `internal/snell-rollcall/docs/oracle-centra.md`.

## Before

```
$ dhs consumer rollcall info 127.0.0.1:2057
error: rollcall: call 0000-08-00:0FF: rollcall: call: NACK
```

## Two defects, both ours

**We asked for a service the peer does not have.** The mask always included
`SV_DISPLAY`; this controller advertises `Menus|Control|File|Map|LongStr` and
refuses the whole call, because services are all-or-nothing. Bracketed: the
identical call without Display succeeds immediately before and after. The mask
is now intersected with what the peer advertised, **per node** — each device-list
entry carries its own services and they differ between the matrices, the panel
node and the gateway.

**We addressed a slot as a port on the gateway's unit.** This controller's
nodes differ by *unit*: Matrix 1 at `0000-11-00`, TIELINES at `0000-80-00`, and
the XY Panel that serves the routing interface at `0000-81-00`. Fourteen of
fifteen were unreachable, and a slot read timed out rather than failing. A slot
is now a position in the device's own enumeration with the address the device
gave it, and that address appears in the slot's identity.

Also: the device map gets **its own session**. A request outside a session's
negotiated services is answered `SP_INVSESS`, so enumerating on the control
session failed. Asked for alone, without the long-string bit — which this
controller refuses in combination and which buys nothing on a fixed-width
structure — with the control session as the fallback.

## After

```
$ dhs consumer rollcall info 127.0.0.1:2057
slots        15
  slot  0   status=present    online=true
  …
  slot 14   status=present    online=true

$ dhs consumer rollcall walk 127.0.0.1:2057 --slot 14
slot 14 — 3 objects
```

Three objects because slot 14 is the XY Panel: a router serves routing and
names as control variables, not menu lines. That is the design document's whole
point and why a menu walk finds nothing on a router.

## The same run validated `codec/router`

Every offset in every sub-table was read individually off the controller, and
its content identifies the field. All four table sizes confirmed (matrix 15,
level 12, source 3, destination 8); `CategoryBase = MatrixBase + N × MatrixStep`
checks out at 151 = 121 + 2×15; source-pin packing confirmed; and the
names-file checksum reproduces the controller's published values **exactly**
for three different files. The package comment no longer calls those offsets
unvalidated.

A live route was set and read back, which established two things a client must
get right: the reply to a set carries the **previous** pin (the new one arrives
as a back-channel push), and the tally **follows tielines** to the upstream
source, so reading back what you wrote is not a valid expectation.

The controller reports interface version **13**; our specification copy
documents 12.

## Coverage

100% of statements in all six packages, unchanged floors. Two test harness
changes were needed and both make the tests more honest: the fake device now
advertises per-node services in its device list (as the vendor does), and the
tests that force a session race now enumerate first, so the gate holds the
racing calls rather than the enumeration that precedes them.

Verified against both the vendor Centra and our own provider from #1025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)