### PR TITLE
feat(snell-rollcall): router control — the Full Control command set client

### DIFF
--- a/internal/snell-rollcall/codec/payload_file.go
+++ b/internal/snell-rollcall/codec/payload_file.go
@@ -364,15 +364,23 @@ func (d DirEntry) AppendTo(dst []byte) ([]byte, error) {
 
 // DecodeDirEntry reads a directory entry.
 //
-// Twenty-three bytes are accepted as well as twenty-four: the content is 23
-// and a peer that trims the structure's padding is not wrong.
+// The name is read as whatever follows the header rather than as a fixed
+// thirteen-byte field, because that is what servers send. The structure
+// declares the field, but the vendor's own controller sends the header
+// followed by the name and its terminator and nothing more: an entry for "."
+// arrives in twelve bytes, one for "TEMPLATE.ZIP" in twenty-three. Demanding
+// the declared width makes every short entry unreadable, which is most of them.
+//
+// A name that fills its field without a terminator is accepted too, which is
+// what a server that does send the full width produces for a thirteen-character
+// name.
 func DecodeDirEntry(b []byte) (DirEntry, error) {
-	const content = FileInfoSize + FileNameSize
-	if err := need(b, content, "DirEntry", ""); err != nil {
+	if err := need(b, FileInfoSize+1, "DirEntry", ""); err != nil {
 		return DirEntry{}, err
 	}
+	name, _ := CString(b[FileInfoSize:])
 	return DirEntry{
 		Info: fileInfoAt(b),
-		Name: fixedString(b[FileInfoSize:content]),
+		Name: name,
 	}, nil
 }

--- a/internal/snell-rollcall/codec/payload_file_test.go
+++ b/internal/snell-rollcall/codec/payload_file_test.go
@@ -296,25 +296,61 @@ func TestDirEntry_PaddedToTwentyFour(t *testing.T) {
 	}
 }
 
-// TestDirEntry_AcceptsTheTrimmedForm covers a peer that sends the 23 bytes of
-// content without the structure's padding. It is not wrong, and the entry must
-// still decode.
-func TestDirEntry_AcceptsTheTrimmedForm(t *testing.T) {
+// TestDirEntry_AcceptsWhatServersActuallySend covers the lengths a directory
+// listing arrives in.
+//
+// The structure declares a thirteen-byte name field, and servers do not send
+// it. These are bytes captured from the vendor's own controller: the header,
+// then the name and its terminator, and nothing else. An entry for "." is
+// twelve bytes. Demanding the declared width makes most of a listing
+// unreadable.
+func TestDirEntry_AcceptsWhatServersActuallySend(t *testing.T) {
+	tests := []struct {
+		name  string
+		bytes string
+		want  DirEntry
+	}{
+		{"the current directory, twelve bytes",
+			"6a9ee2a4" + "0010" + "00000000" + "2e00",
+			DirEntry{Info: FileInfo{Time: 0x6A9EE2A4, Attrib: AttrSubdir}, Name: "."}},
+		{"the parent, thirteen",
+			"6a9ee465" + "0010" + "00000000" + "2e2e00",
+			DirEntry{Info: FileInfo{Time: 0x6A9EE465, Attrib: AttrSubdir}, Name: ".."}},
+		{"a subdirectory, fifteen",
+			"6a9ee2a4" + "0010" + "00000000" + "736f667400",
+			DirEntry{Info: FileInfo{Time: 0x6A9EE2A4, Attrib: AttrSubdir}, Name: "soft"}},
+		{"a file, twenty-three",
+			"6a9ee2a4" + "0000" + "00000be2" + "54454d504c4154452e5a495000",
+			DirEntry{Info: FileInfo{Time: 0x6A9EE2A4, Length: 0x0BE2}, Name: "TEMPLATE.ZIP"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecodeDirEntry(mustHexBytes(tc.bytes))
+			if err != nil {
+				t.Fatalf("DecodeDirEntry: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+
+	// The form our own encoder produces still decodes, name field and all.
 	full, err := DirEntry{Name: "A.TXT"}.AppendTo(nil)
 	if err != nil {
 		t.Fatalf("AppendTo: %v", err)
 	}
-
-	trimmed := full[:FileInfoSize+FileNameSize]
-	got, err := DecodeDirEntry(trimmed)
+	got, err := DecodeDirEntry(full)
 	if err != nil {
-		t.Fatalf("DecodeDirEntry on the trimmed form: %v", err)
+		t.Fatalf("DecodeDirEntry on the full form: %v", err)
 	}
 	if got.Name != "A.TXT" {
 		t.Errorf("name = %q", got.Name)
 	}
 
-	if _, err := DecodeDirEntry(trimmed[:len(trimmed)-1]); !errors.Is(err, ErrShortBuffer) {
+	// The header and at least one byte of name is the least an entry can be.
+	if _, err := DecodeDirEntry(full[:FileInfoSize]); !errors.Is(err, ErrShortBuffer) {
 		t.Errorf("err = %v, want ErrShortBuffer", err)
 	}
 }

--- a/internal/snell-rollcall/consumer/compliance_events.go
+++ b/internal/snell-rollcall/consumer/compliance_events.go
@@ -50,6 +50,19 @@ const (
 	// cached walk does.
 	EventUnsolicitedCommand = "rollcall_unsolicited_command"
 
+	// EventNamesChecksum means a router name file did not hash to the value
+	// the controller published beside its name. The names are kept: they are
+	// probably right, and a client with none at all is worse off than one with
+	// names it cannot prove. What it means in practice is that the cache
+	// cannot be trusted to notice the next change.
+	EventNamesChecksum = "rollcall_names_checksum_mismatch"
+
+	// EventNamesFileUnreadable means a router named a names file that its own
+	// file service would not open. The names are read one command at a time
+	// instead, which is what the file exists to avoid: the fallback works and
+	// is slow, and on a large level it is very slow.
+	EventNamesFileUnreadable = "rollcall_names_file_unreadable"
+
 	// EventUnlistedNode means a slot was addressed that the device's own
 	// enumeration does not mention. It is addressed anyway: a gateway ages a
 	// map entry out after sixty seconds of silence, so a node missing from the

--- a/internal/snell-rollcall/consumer/device_test.go
+++ b/internal/snell-rollcall/consumer/device_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -99,6 +100,10 @@ type device struct {
 	// something other than a device record, which a walker should skip.
 	oddListItem int
 
+	// routers are the ports that serve a routing interface instead of a menu,
+	// which is what a router controller node is.
+	routers map[uint8]*fakeRouter
+
 	// refuseMap makes the device refuse a call asking for the map service,
 	// which is what a gateway that will not open one looks like.
 	refuseMap bool
@@ -161,6 +166,7 @@ func newDevice(t *testing.T, conn net.Conn) *device {
 		oddListItem:   -1,
 		oddDirItem:    -1,
 		emptySlots:    map[uint8]bool{},
+		routers:       map[uint8]*fakeRouter{},
 		failReadAfter: -1,
 		refuse:        make(map[codec.PacketType]bool),
 		garble:        make(map[codec.PacketType]bool),
@@ -292,12 +298,36 @@ type pipeNet struct {
 	t  *testing.T
 	mu sync.Mutex
 	fn func() net.Conn
+
+	// blocked, when set, receives a wrapper whose writes a test can make fail
+	// while its reads go on working: a socket that has gone away without our
+	// end having noticed.
+	blocked **blockedConn
+}
+
+// blockedConn fails writes on demand and leaves reads alone.
+type blockedConn struct {
+	net.Conn
+	failing atomic.Bool
+}
+
+func (c *blockedConn) Write(b []byte) (int, error) {
+	if c.failing.Load() {
+		return 0, io.ErrClosedPipe
+	}
+	return c.Conn.Write(b)
 }
 
 func (p *pipeNet) Dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.fn(), nil
+
+	conn := p.fn()
+	if p.blocked != nil {
+		*p.blocked = &blockedConn{Conn: conn}
+		return *p.blocked, nil
+	}
+	return conn, nil
 }
 
 func (p *pipeNet) Listen(context.Context, string, string) (net.Listener, error) {
@@ -315,11 +345,28 @@ var _ transport.Net = (*pipeNet)(nil)
 // newHarness builds a plugin wired to a fake device, and connects it.
 func newHarness(t *testing.T, setup func(*device)) *harness {
 	t.Helper()
+	h, _ := newHarnessWith(t, setup, false)
+	return h
+}
+
+// newBlockedHarness is a harness whose own writes can be made to fail while
+// what the device sends still arrives.
+func newBlockedHarness(t *testing.T, setup func(*device)) (*harness, **blockedConn) {
+	t.Helper()
+	return newHarnessWith(t, setup, true)
+}
+
+func newHarnessWith(t *testing.T, setup func(*device), blocked bool) (*harness, **blockedConn) {
+	t.Helper()
 
 	clk := clock.NewFake(time.Time{})
 	var dev *device
 
+	var block *blockedConn
 	dialer := &pipeNet{t: t}
+	if blocked {
+		dialer.blocked = &block
+	}
 	dialer.fn = func() net.Conn {
 		ours, theirs := net.Pipe()
 		dev = newDevice(t, theirs)
@@ -347,7 +394,7 @@ func newHarness(t *testing.T, setup func(*device)) *harness {
 			h.device.close()
 		}
 	})
-	return h
+	return h, &block
 }
 
 // menu builds a small but realistic menu: a container with three lines under

--- a/internal/snell-rollcall/consumer/devicehandler_test.go
+++ b/internal/snell-rollcall/consumer/devicehandler_test.go
@@ -434,6 +434,32 @@ func (d *device) getValue(f codec.Frame) {
 	}
 
 	d.mu.Lock()
+	r := d.routers[port]
+	d.mu.Unlock()
+
+	if r != nil {
+		if r.garbled(req.Command) {
+			// A reply too short for the structure it claims to be.
+			d.reply(f, codec.MsgRetValue, []byte{0x01})
+			return
+		}
+		v, mine, ok := r.get(req.Command)
+		if !mine || !ok {
+			// A command outside the routing interface is refused, which is how
+			// a client tells a router node from anything else.
+			d.reply(f, codec.MsgNack, nil)
+			return
+		}
+		payload, err := v.AppendTo(nil)
+		if err != nil {
+			d.t.Errorf("device: encode router value: %v", err)
+			return
+		}
+		d.reply(f, codec.MsgRetValue, payload)
+		return
+	}
+
+	d.mu.Lock()
 	v, ok := d.values[port][req.Command]
 	d.mu.Unlock()
 
@@ -457,6 +483,40 @@ func (d *device) setValueMsg(f codec.Frame) {
 	v, err := codec.DecodeValue(f.Payload)
 	if err != nil {
 		d.reply(f, codec.MsgNack, nil)
+		return
+	}
+
+	d.mu.Lock()
+	r := d.routers[port]
+	d.mu.Unlock()
+
+	if r != nil {
+		if r.garbled(v.Command) {
+			d.reply(f, codec.MsgRetValue, []byte{0x01})
+			return
+		}
+		reply, pushed, mine := r.set(v)
+		if !mine {
+			d.reply(f, codec.MsgNack, nil)
+			return
+		}
+		payload, err := reply.AppendTo(nil)
+		if err != nil {
+			d.t.Errorf("device: encode router reply: %v", err)
+			return
+		}
+		d.reply(f, codec.MsgRetValue, payload)
+
+		// The new value goes out afterwards, on the back channel, which is the
+		// only place a client ever sees it.
+		if pushed != nil {
+			body, err := pushed.AppendTo(nil)
+			if err != nil {
+				d.t.Errorf("device: encode router push: %v", err)
+				return
+			}
+			d.push(port, codec.MsgRetValue, body)
+		}
 		return
 	}
 

--- a/internal/snell-rollcall/consumer/names.go
+++ b/internal/snell-rollcall/consumer/names.go
@@ -1,0 +1,235 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// Names come in bulk or not at all.
+//
+// A level of a large router has tens of thousands of sources and destinations,
+// each with three names. Reading them one command at a time is tens of
+// thousands of round trips, which is why the controller publishes them as files
+// instead: one fetch per level per width, with a checksum that lets a client
+// skip the fetch entirely when what it already has is still current.
+//
+// The checksum is computed from the names, not from the bytes — each name
+// hashed with its own index and the hashes summed — so it survives a controller
+// rewriting the file and changes when any single name does.
+
+// Names are the sources and destinations of one level.
+type Names struct {
+	// Width is the field width these came from: 8 or 32.
+	Width int
+
+	// Srcs and Dsts are indexed from zero, so source n is Srcs[n-1].
+	Srcs []string
+	Dsts []string
+
+	// CRC is what the controller published alongside the filename.
+	CRC uint32
+
+	// Verified says whether the file we read reproduces that checksum. A file
+	// that does not is still returned: the names are probably right and a
+	// client with no names at all is worse off, but the mismatch is recorded.
+	Verified bool
+}
+
+// Name returns a source's name, counting from one.
+func (n Names) Src(i uint32) string { return nameAt(n.Srcs, i) }
+
+// Dst returns a destination's name, counting from one.
+func (n Names) Dst(i uint32) string { return nameAt(n.Dsts, i) }
+
+func nameAt(names []string, i uint32) string {
+	if i < 1 || int(i) > len(names) {
+		return ""
+	}
+	return names[i-1]
+}
+
+// LevelNames fetches the names of one level at the given width.
+//
+// The cache is keyed by the checksum the controller published, so a second call
+// costs nothing and a controller that renames anything invalidates it by
+// itself.
+func (p *Plugin) LevelNames(ctx context.Context, r *RouterInterface,
+	matrix, level uint32, width int) (Names, error) {
+
+	lv, err := r.Level(matrix, level)
+	if err != nil {
+		return Names{}, err
+	}
+
+	file := lv.Names
+	nameOff, dstOff := uint32(router.OffSrcName32), uint32(router.OffDestName32)
+	if width == router.NameWidth8 {
+		file, nameOff, dstOff = lv.Names8, router.OffSrcName8, router.OffDestName8
+	}
+
+	if !file.Empty() {
+		names, err := p.namesFile(ctx, r.Slot, file, width, int(lv.Srcs.Count), int(lv.Dsts.Count))
+		if err == nil {
+			return names, nil
+		}
+		// The controller named a file it will not serve. That happens: the
+		// name is a path in the controller's own filesystem, and the file
+		// service on a node is rooted at that node's own directory, so the two
+		// need not meet. One command per name is what is left.
+		p.fire(EventNamesFileUnreadable, fmt.Sprintf(
+			"%s could not be read (%v); falling back to one command per name", file.Name, err))
+	}
+
+	return p.namesByCommand(ctx, r, lv, width, nameOff, dstOff)
+}
+
+// namesByCommand reads a level's names one command at a time.
+//
+// This is what the file mechanism exists to avoid: a level of sixty-five
+// thousand sources costs sixty-five thousand round trips here. It is the
+// fallback rather than the method, and a caller reaching it on a large level
+// should expect to wait.
+func (p *Plugin) namesByCommand(ctx context.Context, r *RouterInterface,
+	lv *RouterLevel, width int, srcOff, dstOff uint32) (Names, error) {
+
+	names := Names{Width: width}
+
+	for i := uint32(1); i <= lv.Srcs.Count; i++ {
+		cmd, ok := lv.Srcs.Field(i, srcOff)
+		if !ok {
+			break
+		}
+		n, err := p.readString(ctx, r.Slot, uint32(cmd))
+		if err != nil {
+			return names, err
+		}
+		names.Srcs = append(names.Srcs, n)
+	}
+	for i := uint32(1); i <= lv.Dsts.Count; i++ {
+		cmd, ok := lv.Dsts.Field(i, dstOff)
+		if !ok {
+			break
+		}
+		n, err := p.readString(ctx, r.Slot, uint32(cmd))
+		if err != nil {
+			return names, err
+		}
+		names.Dsts = append(names.Dsts, n)
+	}
+	return names, nil
+}
+
+// AssociationNames fetches a matrix's association names.
+//
+// An association groups one entity per level, and it is what a panel actually
+// shows: an operator picks a destination association and takes a source
+// association, and the controller routes every level underneath.
+func (p *Plugin) AssociationNames(ctx context.Context, r *RouterInterface,
+	matrix uint32, width int) (Names, error) {
+
+	m, err := r.Matrix(matrix)
+	if err != nil {
+		return Names{}, err
+	}
+
+	file := m.AssocNames
+	if width == router.NameWidth8 {
+		file = m.AssocNames8
+	}
+	if file.Empty() {
+		return Names{}, fmt.Errorf(
+			"rollcall: matrix %d publishes no %d-character association names file", matrix, width)
+	}
+
+	return p.namesFile(ctx, r.Slot, file, width,
+		int(m.SrcAssocs.Count), int(m.DstAssocs.Count))
+}
+
+// Mappings fetches which entity each association reaches on each level.
+func (p *Plugin) Mappings(ctx context.Context, r *RouterInterface,
+	matrix uint32) (router.MappingsFile, error) {
+
+	m, err := r.Matrix(matrix)
+	if err != nil {
+		return router.MappingsFile{}, err
+	}
+	if m.AssocMappings.Empty() {
+		return router.MappingsFile{}, fmt.Errorf(
+			"rollcall: matrix %d publishes no association mappings file", matrix)
+	}
+
+	body, err := p.ReadFile(ctx, r.Slot, m.AssocMappings.Name)
+	if err != nil {
+		return router.MappingsFile{}, err
+	}
+
+	mf, err := router.DecodeMappingsFile(body, len(m.Levels),
+		int(m.SrcAssocs.Count), int(m.DstAssocs.Count))
+	if err != nil {
+		return router.MappingsFile{}, fmt.Errorf("rollcall: %s: %w", m.AssocMappings.Name, err)
+	}
+	if crc := mf.CRC(); crc != m.AssocMappings.CRC {
+		p.fire(EventNamesChecksum, fmt.Sprintf(
+			"%s hashes to %08X, and the router published %08X",
+			m.AssocMappings.Name, crc, m.AssocMappings.CRC))
+	}
+	return mf, nil
+}
+
+// namesFile fetches and decodes one names file, checking what came back
+// against the checksum the controller published.
+func (p *Plugin) namesFile(ctx context.Context, slot int, file RouterFile,
+	width, srcs, dsts int) (Names, error) {
+
+	if cached, ok := p.cachedNames(file.CRC, width); ok {
+		return cached, nil
+	}
+
+	body, err := p.ReadFile(ctx, slot, file.Name)
+	if err != nil {
+		return Names{}, err
+	}
+
+	nf, err := router.DecodeNamesFile(body, width, srcs, dsts)
+	if err != nil {
+		return Names{}, fmt.Errorf("rollcall: %s: %w", file.Name, err)
+	}
+
+	names := Names{Width: width, Srcs: nf.Srcs, Dsts: nf.Dsts, CRC: file.CRC}
+	if crc := nf.CRC(); crc == file.CRC {
+		names.Verified = true
+	} else {
+		// The names are probably right and a client with none at all is worse
+		// off, so they are kept; the mismatch is what gets reported.
+		p.fire(EventNamesChecksum, fmt.Sprintf(
+			"%s hashes to %08X, and the router published %08X", file.Name, crc, file.CRC))
+	}
+
+	p.cacheNames(file.CRC, width, names)
+	return names, nil
+}
+
+// namesKey identifies a cached names file. The checksum alone would collide
+// between widths on a level whose two files happen to hash alike.
+type namesKey struct {
+	crc   uint32
+	width int
+}
+
+func (p *Plugin) cachedNames(crc uint32, width int) (Names, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	n, ok := p.names[namesKey{crc: crc, width: width}]
+	return n, ok
+}
+
+func (p *Plugin) cacheNames(crc uint32, width int, n Names) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.names == nil {
+		p.names = make(map[namesKey]Names)
+	}
+	p.names[namesKey{crc: crc, width: width}] = n
+}

--- a/internal/snell-rollcall/consumer/names_test.go
+++ b/internal/snell-rollcall/consumer/names_test.go
@@ -1,0 +1,351 @@
+package rollcall
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// Names come in bulk or not at all: a level of sixty-five thousand sources is
+// sixty-five thousand round trips the other way, which is what the file
+// mechanism exists to avoid.
+
+func TestLevelNamesInBulk(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		width    int
+		firstSrc string
+		firstDst string
+	}{
+		{router.NameWidth8, "M1L1S1", "M1L1D1"},
+		{router.NameWidth32, "matrix1 level1 source1", "matrix1 level1 dest1"},
+	} {
+		names, err := h.plugin.LevelNames(ctx, r, 1, 1, tc.width)
+		if err != nil {
+			t.Fatalf("width %d: %v", tc.width, err)
+		}
+		if !names.Verified {
+			t.Errorf("width %d: the file did not reproduce the published checksum", tc.width)
+		}
+		if len(names.Srcs) != 10 || len(names.Dsts) != 10 {
+			t.Fatalf("width %d: %d sources and %d destinations",
+				tc.width, len(names.Srcs), len(names.Dsts))
+		}
+		// Counting from one, because that is how the command space counts.
+		if got := names.Src(1); got != tc.firstSrc {
+			t.Errorf("width %d: source 1 = %q, want %q", tc.width, got, tc.firstSrc)
+		}
+		if got := names.Dst(1); got != tc.firstDst {
+			t.Errorf("width %d: destination 1 = %q, want %q", tc.width, got, tc.firstDst)
+		}
+	}
+}
+
+func TestNamesOutsideTheirRange(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	names, err := h.plugin.LevelNames(context.Background(), r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	for _, i := range []uint32{0, 11, 9999} {
+		if got := names.Src(i); got != "" {
+			t.Errorf("source %d = %q, want nothing", i, got)
+		}
+		if got := names.Dst(i); got != "" {
+			t.Errorf("destination %d = %q, want nothing", i, got)
+		}
+	}
+}
+
+func TestNamesAreCachedByTheirChecksum(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	if _, err := h.plugin.LevelNames(ctx, r, 1, 1, router.NameWidth32); err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+
+	// Take the file away. A second call must not need it: the checksum the
+	// controller published is what identifies what we already hold, and
+	// re-fetching a level's names on every lookup is the cost this avoids.
+	lv, err := r.Level(1, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	h.device.mu.Lock()
+	delete(h.device.files, lv.Names.Name)
+	h.device.mu.Unlock()
+
+	names, err := h.plugin.LevelNames(ctx, r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("the second call went back to the device: %v", err)
+	}
+	if names.Src(2) != "matrix1 level2 source2" && names.Src(2) != "matrix1 level1 source2" {
+		t.Errorf("cached names look wrong: %q", names.Src(2))
+	}
+
+	// The two widths are cached apart, so one does not answer for the other.
+	eight, err := h.plugin.LevelNames(ctx, r, 1, 1, router.NameWidth8)
+	if err != nil {
+		t.Fatalf("the 8-character names: %v", err)
+	}
+	if eight.Width != router.NameWidth8 || eight.Src(1) != "M1L1S1" {
+		t.Errorf("width %d gave %q", eight.Width, eight.Src(1))
+	}
+}
+
+func TestNamesFallBackToOneCommandPerName(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	// A controller can name a file its own file service will not serve: the
+	// name is a path in the controller's filesystem, and a node's file service
+	// is rooted at that node's directory. The vendor Centra does exactly this.
+	lv, err := r.Level(2, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	h.device.mu.Lock()
+	delete(h.device.files, lv.Names.Name)
+	h.device.mu.Unlock()
+
+	names, err := h.plugin.LevelNames(ctx, r, 2, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	if got := names.Src(3); got != "matrix2 level1 source3" {
+		t.Errorf("source 3 = %q", got)
+	}
+	if got := names.Dst(4); got != "matrix2 level1 dest4" {
+		t.Errorf("destination 4 = %q", got)
+	}
+	// Nothing was verified: there was no file to hash.
+	if names.Verified {
+		t.Error("names read command by command cannot be verified against a checksum")
+	}
+	if !hasEvent(h.plugin, EventNamesFileUnreadable) {
+		t.Error("falling back should be recorded; it is much slower and silent otherwise")
+	}
+}
+
+func TestNamesWithNoFileAtAll(t *testing.T) {
+	// A level that publishes no names file at all goes straight to the
+	// per-command path rather than reporting nothing.
+	h, r := routerHarness(t, func(f *fakeRouter) {
+		f.values[121+router.MatrixTableSize+0] = f.values[121] // harmless
+	})
+	ctx := context.Background()
+
+	lv, err := r.Level(1, 2)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	lv.Names = RouterFile{}
+	lv.Names8 = RouterFile{}
+
+	names, err := h.plugin.LevelNames(ctx, r, 1, 2, router.NameWidth8)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	if got := names.Src(1); got != "M1L2S1" {
+		t.Errorf("source 1 = %q", got)
+	}
+}
+
+func TestNamesThatDoNotMatchTheirChecksum(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	lv, err := r.Level(1, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+
+	// Replace the file with different names of the same shape. The checksum
+	// the controller published no longer describes it.
+	other := router.NamesFile{Width: router.NameWidth32}
+	for i := 0; i < 10; i++ {
+		other.Srcs = append(other.Srcs, "something else")
+		other.Dsts = append(other.Dsts, "something else")
+	}
+	body, err := other.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("AppendTo: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.files[lv.Names.Name] = body
+	h.device.mu.Unlock()
+
+	names, err := h.plugin.LevelNames(ctx, r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	// The names are kept: they are probably right, and a client with none is
+	// worse off than one with names it cannot prove.
+	if names.Verified {
+		t.Error("a file that does not hash to its published checksum was reported as verified")
+	}
+	if names.Src(1) != "something else" {
+		t.Errorf("the names were discarded: %q", names.Src(1))
+	}
+	if !hasEvent(h.plugin, EventNamesChecksum) {
+		t.Error("a checksum mismatch should be recorded")
+	}
+}
+
+func TestAssociationNamesAndMappings(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	names, err := h.plugin.AssociationNames(ctx, r, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("AssociationNames: %v", err)
+	}
+	if !names.Verified {
+		t.Error("the association names did not reproduce their checksum")
+	}
+	if got := names.Src(2); got != "matrix1 source assoc 2" {
+		t.Errorf("source association 2 = %q", got)
+	}
+
+	short, err := h.plugin.AssociationNames(ctx, r, 1, router.NameWidth8)
+	if err != nil {
+		t.Fatalf("AssociationNames at 8: %v", err)
+	}
+	if got := short.Dst(1); got != "M1DA1" {
+		t.Errorf("destination association 1 = %q", got)
+	}
+
+	// An association groups one entity per level, which is what makes routing
+	// by association route every level at once.
+	mf, err := h.plugin.Mappings(ctx, r, 1)
+	if err != nil {
+		t.Fatalf("Mappings: %v", err)
+	}
+	if mf.Levels != 2 {
+		t.Errorf("%d levels in the mappings, want 2", mf.Levels)
+	}
+	if len(mf.Srcs) != 10 || len(mf.Srcs[0]) != 2 {
+		t.Fatalf("mappings shape = %d associations of %d", len(mf.Srcs), len(mf.Srcs[0]))
+	}
+	if mf.Srcs[2][0] != 3 || mf.Srcs[2][1] != 3 {
+		t.Errorf("association 3 maps to %v, want entity 3 on both levels", mf.Srcs[2])
+	}
+}
+
+func TestNamesForThingsTheRouterDoesNotHave(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	if _, err := h.plugin.LevelNames(ctx, r, 9, 1, router.NameWidth32); err == nil {
+		t.Error("names for a matrix past the end should fail")
+	}
+	if _, err := h.plugin.AssociationNames(ctx, r, 9, router.NameWidth32); err == nil {
+		t.Error("association names for a matrix past the end should fail")
+	}
+	if _, err := h.plugin.Mappings(ctx, r, 9); err == nil {
+		t.Error("mappings for a matrix past the end should fail")
+	}
+
+	// A matrix that publishes no association file cannot supply the names, and
+	// there is no per-command fallback for associations: the commands do not
+	// exist.
+	m, err := r.Matrix(2)
+	if err != nil {
+		t.Fatalf("Matrix: %v", err)
+	}
+	m.AssocNames = RouterFile{}
+	m.AssocNames8 = RouterFile{}
+	m.AssocMappings = RouterFile{}
+
+	if _, err := h.plugin.AssociationNames(ctx, r, 2, router.NameWidth32); err == nil {
+		t.Error("a matrix with no association names file should say so")
+	}
+	if _, err := h.plugin.Mappings(ctx, r, 2); err == nil {
+		t.Error("a matrix with no mappings file should say so")
+	}
+}
+
+func TestMappingsThatWillNotDecode(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	m, err := r.Matrix(1)
+	if err != nil {
+		t.Fatalf("Matrix: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.files[m.AssocMappings.Name] = []byte{0x01}
+	h.device.mu.Unlock()
+
+	if _, err := h.plugin.Mappings(ctx, r, 1); err == nil {
+		t.Error("a mappings file too short for its declared contents should fail")
+	}
+
+	// And one that decodes but hashes to something else is kept with the
+	// mismatch recorded, the same as a names file.
+	other := router.MappingsFile{Levels: 2}
+	for i := 0; i < 10; i++ {
+		other.Srcs = append(other.Srcs, []uint32{9, 9})
+		other.Dsts = append(other.Dsts, []uint32{9, 9})
+	}
+	h.device.mu.Lock()
+	h.device.files[m.AssocMappings.Name] = other.AppendTo(nil)
+	h.device.mu.Unlock()
+
+	got, err := h.plugin.Mappings(ctx, r, 1)
+	if err != nil {
+		t.Fatalf("Mappings: %v", err)
+	}
+	if got.Srcs[0][0] != 9 {
+		t.Errorf("the mappings were discarded: %v", got.Srcs[0])
+	}
+	if !hasEvent(h.plugin, EventNamesChecksum) {
+		t.Error("a mappings checksum mismatch should be recorded")
+	}
+}
+
+func TestNamesWhenTheDeviceStopsAnswering(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	lv, err := r.Level(2, 2)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	h.device.mu.Lock()
+	delete(h.device.files, lv.Names.Name)
+	h.device.mu.Unlock()
+
+	// The file is gone and the per-name commands are refused too, so there is
+	// nothing left to fall back to.
+	cmd, err := r.srcCommand(2, 2, 1, router.OffSrcName32)
+	if err != nil {
+		t.Fatalf("srcCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].refuse[cmd] = true
+	h.device.mu.Unlock()
+
+	if _, err := h.plugin.LevelNames(ctx, r, 2, 2, router.NameWidth32); err == nil {
+		t.Error("names that cannot be read either way should fail")
+	}
+
+	// The same on the destination side.
+	dst, err := r.destCommand(2, 2, 1, router.OffDestName32)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	delete(h.device.routers[2].refuse, cmd)
+	h.device.routers[2].refuse[dst] = true
+	h.device.mu.Unlock()
+
+	if _, err := h.plugin.LevelNames(ctx, r, 2, 2, router.NameWidth32); err == nil {
+		t.Error("destination names that cannot be read should fail")
+	}
+}

--- a/internal/snell-rollcall/consumer/plugin.go
+++ b/internal/snell-rollcall/consumer/plugin.go
@@ -102,6 +102,12 @@ type Plugin struct {
 	// path resolvable without walking again.
 	trees map[int]*slotTree
 
+	// names caches the router name files by the checksum the controller
+	// published. A large level's names are tens of thousands of strings and
+	// they change only when somebody renames something, which is exactly what
+	// the checksum detects.
+	names map[namesKey]Names
+
 	// nodeCache is the device's enumerated nodes, walked once per connection.
 	// It is what turns a slot number into an address, and a controller's nodes
 	// are unreachable without it.

--- a/internal/snell-rollcall/consumer/route.go
+++ b/internal/snell-rollcall/consumer/route.go
@@ -1,0 +1,302 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/dtp"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// Reading and changing crosspoints, once the model in router.go says where
+// they live.
+
+// Crosspoint is what a destination currently has, as the controller sees it.
+type Crosspoint struct {
+	// Dest identifies the destination this describes.
+	Dest router.SourcePin
+
+	// Source is what is routed to it. Zero means nothing is.
+	//
+	// It is the *final upstream* source: where a route crosses a tieline the
+	// controller reports the far end, so this is often not the pin that was
+	// written. That is the protocol working, not a fault.
+	Source router.SourcePin
+
+	// Result is the outcome of the last change to this destination, when the
+	// controller supplied one. It is always present in the answer to a set and
+	// optional on a read.
+	Result router.RouteResult
+
+	// HasResult says whether Result came from the controller or is a zero
+	// value nobody set.
+	HasResult bool
+}
+
+// Protect is the protect state of a destination.
+type Protect struct {
+	// On says whether the destination is protected.
+	On bool
+
+	// ID is the panel that protected it, in the range 1..1023, or zero when it
+	// is not protected. A panel may only release a protect carrying its own
+	// id; a master panel may release any.
+	ID uint16
+
+	// By is the name of the device holding the protect, when the controller
+	// supplied one.
+	By string
+}
+
+// Route reads what is routed to one destination.
+//
+// The destination is named by matrix, level and number, which is how the
+// command space is addressed: the same destination number means a different
+// thing on each level.
+func (p *Plugin) Route(ctx context.Context, r *RouterInterface,
+	matrix, level, dest uint32) (Crosspoint, error) {
+
+	cmd, err := r.destCommand(matrix, level, dest, router.OffDestRoutedSrc)
+	if err != nil {
+		return Crosspoint{}, err
+	}
+
+	v, err := p.readValue(ctx, r.Slot, cmd)
+	if err != nil {
+		return Crosspoint{}, err
+	}
+	return decodeCrosspoint(v, router.SourcePin{
+		Matrix: uint8(matrix), Level: uint8(level), Source: uint16(dest),
+	})
+}
+
+// SetRoute routes a source to a destination and returns what the controller
+// said about it.
+//
+// What comes back is not the new crosspoint. The controller answers with the
+// pin that was routed *before* the change, plus a result code saying whether
+// the change worked; the new pin arrives afterwards as a back-channel push. A
+// caller that wants to see the result rather than believe it should subscribe
+// before setting, or read again after.
+//
+// The protect id is optional and rarely wanted: it is a temporary override for
+// local routing, and passing zero asks for an ordinary route.
+func (p *Plugin) SetRoute(ctx context.Context, r *RouterInterface,
+	matrix, level, dest uint32, src router.SourcePin, protectID uint16) (Crosspoint, error) {
+
+	cmd, err := r.destCommand(matrix, level, dest, router.OffDestRoutedSrc)
+	if err != nil {
+		return Crosspoint{}, err
+	}
+
+	// The pin goes in a uint array, not as a bare uint: one entry to route,
+	// two when a protect id comes with it.
+	pins := []uint32{src.Pack()}
+	if protectID != 0 {
+		pins = append(pins, uint32(protectID))
+	}
+	// Neither encode can fail: Data Transfer Params refuse only strings that
+	// are too long and more items than a packet holds, and this is one or two
+	// numbers; a value in data mode has no field that can overflow.
+	payload, _ := dtp.Encode(dtp.Params{dtp.Uints(pins...)}, false)
+	req, _ := codec.Value{Command: cmd, Mode: codec.ModeData, Data: payload}.AppendTo(nil)
+
+	s, err := p.session(ctx, r.Slot)
+	if err != nil {
+		return Crosspoint{}, err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgSetValue, req)
+	if err != nil {
+		return Crosspoint{}, fmt.Errorf("rollcall: route %s to matrix %d level %d dest %d: %w",
+			src, matrix, level, dest, err)
+	}
+	v, err := codec.DecodeValue(reply.Payload)
+	if err != nil {
+		return Crosspoint{}, fmt.Errorf("rollcall: route reply: %w", err)
+	}
+
+	xpt, err := decodeCrosspoint(v, router.SourcePin{
+		Matrix: uint8(matrix), Level: uint8(level), Source: uint16(dest),
+	})
+	if err != nil {
+		return Crosspoint{}, err
+	}
+	if xpt.HasResult && !xpt.Result.OK() {
+		return xpt, fmt.Errorf("rollcall: route %s to matrix %d level %d dest %d: %s",
+			src, matrix, level, dest, xpt.Result)
+	}
+	return xpt, nil
+}
+
+// Protect reads a destination's protect state.
+func (p *Plugin) Protect(ctx context.Context, r *RouterInterface,
+	matrix, level, dest uint32) (Protect, error) {
+
+	cmd, err := r.destCommand(matrix, level, dest, router.OffDestProtect)
+	if err != nil {
+		return Protect{}, err
+	}
+
+	v, err := p.readValue(ctx, r.Slot, cmd)
+	if err != nil {
+		return Protect{}, err
+	}
+
+	st := router.UnpackProtectState(uint32(v.Val))
+	return Protect{On: st.Protected, ID: st.DeviceID, By: v.Text}, nil
+}
+
+// SetProtect protects or releases a destination.
+//
+// The id is the panel's own, and it decides who may release: an ordinary panel
+// may only release a protect carrying the same id, while a master panel may
+// release any. A protect with no id is refused rather than sent, because a
+// controller cannot attribute it and no panel could ever release it.
+func (p *Plugin) SetProtect(ctx context.Context, r *RouterInterface,
+	matrix, level, dest uint32, on bool, id uint16, master bool) (Protect, error) {
+
+	if id == 0 || id > router.MaxProtectID {
+		// Zero cannot be attributed and nothing could ever release it; past
+		// the configured range means the word was built wrongly, and the
+		// controller would attribute the protect to a panel that cannot exist.
+		return Protect{}, fmt.Errorf(
+			"rollcall: a protect needs a panel id in 1..%d, not %d", router.MaxProtectID, id)
+	}
+
+	cmd, err := r.destCommand(matrix, level, dest, router.OffDestProtect)
+	if err != nil {
+		return Protect{}, err
+	}
+
+	state := router.PackProtectState(router.ProtectState{Protected: on, DeviceID: id, Master: master})
+
+	s, err := p.session(ctx, r.Slot)
+	if err != nil {
+		return Protect{}, err
+	}
+	// A numeric value has no field that can overflow.
+	req, _ := codec.Value{Command: cmd, Mode: codec.ModeValue, Val: int32(state)}.AppendTo(nil)
+
+	reply, err := s.Do(ctx, codec.MsgSetValue, req)
+	if err != nil {
+		return Protect{}, fmt.Errorf("rollcall: protect matrix %d level %d dest %d: %w",
+			matrix, level, dest, err)
+	}
+	v, err := codec.DecodeValue(reply.Payload)
+	if err != nil {
+		return Protect{}, fmt.Errorf("rollcall: protect reply: %w", err)
+	}
+
+	st := router.UnpackProtectState(uint32(v.Val))
+	return Protect{On: st.Protected, ID: st.DeviceID, By: v.Text}, nil
+}
+
+// FireSalvo asks the controller to run a salvo, counting from one.
+func (p *Plugin) FireSalvo(ctx context.Context, r *RouterInterface, salvo uint32) error {
+	if r.Version < router.VersionSalvos {
+		return fmt.Errorf("rollcall: this router's interface is version %d; salvos arrived at %d",
+			r.Version, router.VersionSalvos)
+	}
+	if salvo < 1 || salvo > r.Salvos {
+		return fmt.Errorf("rollcall: salvo %d is outside the %d this router holds", salvo, r.Salvos)
+	}
+
+	// One number, in data mode: neither encode has a way to fail.
+	payload, _ := dtp.Encode(dtp.Params{dtp.Uint(salvo)}, false)
+	req, _ := codec.Value{
+		Command: uint32(router.CmdFireSalvo), Mode: codec.ModeData, Data: payload,
+	}.AppendTo(nil)
+
+	s, err := p.session(ctx, r.Slot)
+	if err != nil {
+		return err
+	}
+	if _, err := s.Do(ctx, codec.MsgSetValue, req); err != nil {
+		return fmt.Errorf("rollcall: fire salvo %d: %w", salvo, err)
+	}
+	return nil
+}
+
+// destCommand finds the command at an offset in a destination's own table.
+func (r *RouterInterface) destCommand(matrix, level, dest, offset uint32) (uint32, error) {
+	lv, err := r.Level(matrix, level)
+	if err != nil {
+		return 0, err
+	}
+	cmd, ok := lv.Dsts.Field(dest, offset)
+	if !ok {
+		return 0, fmt.Errorf(
+			"rollcall: matrix %d level %d has %d destinations, so %d is not one of them",
+			matrix, level, lv.Dsts.Count, dest)
+	}
+	return uint32(cmd), nil
+}
+
+// srcCommand finds the command at an offset in a source's own table.
+func (r *RouterInterface) srcCommand(matrix, level, src, offset uint32) (uint32, error) {
+	lv, err := r.Level(matrix, level)
+	if err != nil {
+		return 0, err
+	}
+	cmd, ok := lv.Srcs.Field(src, offset)
+	if !ok {
+		return 0, fmt.Errorf(
+			"rollcall: matrix %d level %d has %d sources, so %d is not one of them",
+			matrix, level, lv.Srcs.Count, src)
+	}
+	return uint32(cmd), nil
+}
+
+// Matrix returns one matrix by its number, counting from one.
+func (r *RouterInterface) Matrix(n uint32) (*RouterMatrix, error) {
+	if n < 1 || int(n) > len(r.Matrices) {
+		return nil, fmt.Errorf("rollcall: this router has %d matrices, so %d is not one of them",
+			len(r.Matrices), n)
+	}
+	return &r.Matrices[n-1], nil
+}
+
+// Level returns one level of one matrix, both counting from one.
+func (r *RouterInterface) Level(matrix, level uint32) (*RouterLevel, error) {
+	m, err := r.Matrix(matrix)
+	if err != nil {
+		return nil, err
+	}
+	if level < 1 || int(level) > len(m.Levels) {
+		return nil, fmt.Errorf("rollcall: matrix %d has %d levels, so %d is not one of them",
+			matrix, len(m.Levels), level)
+	}
+	return &m.Levels[level-1], nil
+}
+
+// decodeCrosspoint reads the Data Transfer Params a routed-source command
+// carries: the pin, and optionally the result of the last change.
+func decodeCrosspoint(v codec.Value, dest router.SourcePin) (Crosspoint, error) {
+	xpt := Crosspoint{Dest: dest}
+
+	if len(v.Data) == 0 {
+		// A destination with nothing routed to it and nothing to report.
+		return xpt, nil
+	}
+
+	items, err := dtp.Decode(v.Data)
+	if err != nil {
+		return Crosspoint{}, fmt.Errorf("rollcall: crosspoint: %w", err)
+	}
+
+	for i, it := range items {
+		switch {
+		case i == 0 && it.Type == dtp.TypeUint:
+			xpt.Source = router.UnpackSourcePin(it.Uint)
+		case i == 0 && it.Type == dtp.TypeUintArray && len(it.Uints) > 0:
+			// A controller may answer with the array form it accepts.
+			xpt.Source = router.UnpackSourcePin(it.Uints[0])
+		case i == 1 && it.Type == dtp.TypeUint:
+			xpt.Result = router.RouteResult(it.Uint)
+			xpt.HasResult = true
+		}
+	}
+	return xpt, nil
+}

--- a/internal/snell-rollcall/consumer/router.go
+++ b/internal/snell-rollcall/consumer/router.go
@@ -1,0 +1,455 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/dtp"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// A router has no menu, and that is the whole difference.
+//
+// Every other RollCall device describes itself through the menu service: a
+// client walks the lines and learns what commands exist. A router controller
+// serves its routing, its names, its protects and its salvos as control
+// variables instead, in a flat 32-bit command space whose numbers a client
+// works out by arithmetic from a root table at command 100. Walking a router's
+// menu finds three lines and nothing useful.
+//
+// So this file is discovery of a different kind: read the root table, follow
+// the bases and steps it publishes down through matrices, levels, sources and
+// destinations, and address a crosspoint by the command number that falls out.
+// The arithmetic lives in codec/router, measured against a vendor controller;
+// what lives here is the reading, the caching and the two behaviours a client
+// gets wrong if nobody tells it:
+//
+//   - The reply to a route set carries the value from *before* the set. The
+//     new one arrives on the back channel.
+//   - The tally follows tielines. Setting source 7 can read back as matrix 2
+//     source 1, because the pin reports the final upstream source rather than
+//     what was asked for.
+
+// RouterInterface is what a router node publishes about itself.
+type RouterInterface struct {
+	// Slot is the node this was read from, and Addr the address behind it.
+	Slot int
+	Addr codec.Address
+
+	// Version is the interface revision. Commands are only ever added, so it
+	// says which of them exist: anything introduced after this is absent.
+	Version uint32
+
+	// Name is what the router calls itself.
+	Name string
+
+	// Matrices are its matrices, in order.
+	Matrices []RouterMatrix
+
+	// Salvos is how many salvos it holds, and SalvoNames8 / SalvoNames32 the
+	// files their names are in.
+	Salvos      uint32
+	SalvoNames8 RouterFile
+	SalvoNames  RouterFile
+
+	// Devices is how many external devices it knows, and DeviceNames the file
+	// naming them.
+	Devices     uint32
+	DeviceNames RouterFile
+
+	// Categories is the category table, which groups sources and destinations
+	// for a panel's filter buttons.
+	Categories router.Table
+}
+
+// RouterMatrix is one matrix of a router.
+type RouterMatrix struct {
+	Number uint32
+	Name   string
+
+	// Controller is the controller number this matrix lives on, which is what
+	// tells two matrices of one router apart on a replicated system.
+	Controller int32
+
+	Levels []RouterLevel
+
+	// SrcAssocs and DstAssocs are the association tables. An association
+	// groups one entity per level so that routing by association routes every
+	// level at once, which is how a panel with level buttons works.
+	SrcAssocs router.Table
+	DstAssocs router.Table
+
+	// AssocNames8, AssocNames and AssocNamesAlt are the association name files
+	// at their three widths; AssocMappings says which entity each association
+	// reaches on each level.
+	AssocNames8   RouterFile
+	AssocNames    RouterFile
+	AssocNamesAlt RouterFile
+	AssocMappings RouterFile
+}
+
+// RouterLevel is one level of one matrix: a plane of crosspoints.
+type RouterLevel struct {
+	Number uint32
+	Name   string
+
+	// Kind is the level type the controller published. Zero is the ordinary
+	// one; the rest are not documented anywhere we hold.
+	Kind int32
+
+	// Srcs and Dsts are the entity tables. A source's commands are its names;
+	// a destination's are its names, its routed source and its protect.
+	Srcs router.Table
+	Dsts router.Table
+
+	// Names8, Names and NamesAlt are the collated source-and-destination name
+	// files at their three widths, and MCData the multi-channel configuration.
+	Names8   RouterFile
+	Names    RouterFile
+	NamesAlt RouterFile
+	MCData   RouterFile
+}
+
+// RouterFile is a file the controller publishes, named with a checksum.
+//
+// The checksum is what makes caching possible: it is computed from the names
+// themselves rather than from the bytes, so a client that has the file already
+// can tell it is still current without fetching it. Sixty-five thousand names
+// per level is why that matters.
+type RouterFile struct {
+	Name string
+	CRC  uint32
+}
+
+// Empty reports whether the controller named a file at all.
+func (f RouterFile) Empty() bool { return f.Name == "" }
+
+// RouterAt reads the routing interface a node publishes.
+//
+// A node that is not a router refuses command 100, which is how a client tells
+// them apart: the controller answers, its matrices refuse, and refusing is not
+// a fault.
+func (p *Plugin) RouterAt(ctx context.Context, slot int) (*RouterInterface, error) {
+	s, err := p.session(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	if !s.Uses32Bit() {
+		// The command set exists only on the 32-bit generation: a matrix of
+		// any useful size needs more command numbers than the 16-bit field
+		// holds, which is what the long-string extension was written for.
+		return nil, fmt.Errorf(
+			"rollcall: slot %d speaks the 16-bit generation, which has no routing interface", slot)
+	}
+
+	r := &RouterInterface{Slot: slot, Addr: s.Peer()}
+
+	version, err := p.readUint(ctx, slot, uint32(router.CmdInterfaceVersion))
+	if err != nil {
+		return nil, fmt.Errorf("rollcall: slot %d has no routing interface: %w", slot, err)
+	}
+	r.Version = version
+
+	if r.Name, err = p.readString(ctx, slot, uint32(router.CmdRouterName)); err != nil {
+		return nil, err
+	}
+
+	matrices, err := p.readTable(ctx, slot,
+		uint32(router.CmdNumMatrices), uint32(router.CmdMatrixBase), uint32(router.CmdMatrixStep))
+	if err != nil {
+		return nil, err
+	}
+	if r.Categories, err = p.readTable(ctx, slot,
+		uint32(router.CmdNumCategories), uint32(router.CmdCategoryBase),
+		uint32(router.CmdCategoryStep)); err != nil {
+		return nil, err
+	}
+
+	// Salvos and device names arrived at known interface versions. Reading a
+	// command the controller does not have is a refusal rather than a fault,
+	// but asking anyway would fire a compliance event for something the
+	// version already told us, so the version decides.
+	if r.Version >= router.VersionSalvos {
+		if r.Salvos, err = p.readUint(ctx, slot, uint32(router.CmdNumSalvos)); err != nil {
+			return nil, err
+		}
+		if r.SalvoNames8, err = p.readFile(ctx, slot, uint32(router.CmdSalvoNames8File)); err != nil {
+			return nil, err
+		}
+		if r.SalvoNames, err = p.readFile(ctx, slot, uint32(router.CmdSalvoNames32File)); err != nil {
+			return nil, err
+		}
+	}
+	if r.Version >= router.VersionDeviceNames {
+		if r.Devices, err = p.readUint(ctx, slot, uint32(router.CmdNumDevices)); err != nil {
+			return nil, err
+		}
+		if r.DeviceNames, err = p.readFile(ctx, slot, uint32(router.CmdDeviceNamesFile)); err != nil {
+			return nil, err
+		}
+	}
+
+	for m := uint32(1); m <= matrices.Count; m++ {
+		mx, err := p.readMatrix(ctx, slot, matrices, m)
+		if err != nil {
+			return nil, err
+		}
+		r.Matrices = append(r.Matrices, mx)
+	}
+	return r, nil
+}
+
+// FindRouter looks for a routing interface on any node the device enumerated.
+//
+// Probing is safe because a node without one refuses command 100 rather than
+// misbehaving, and it is necessary because nothing in a device list says which
+// node is the panel driver: on the vendor Centra the matrices are their own
+// nodes and neither of them serves the interface.
+func (p *Plugin) FindRouter(ctx context.Context) (*RouterInterface, error) {
+	t, err := p.nodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// The table always holds at least the device itself, so there is always
+	// something to probe and always a reason to report when none of them
+	// answers.
+	var last error
+	for slot := range t.addrs {
+		r, err := p.RouterAt(ctx, slot)
+		if err == nil {
+			p.log.Debug("rollcall: found a routing interface",
+				"slot", slot, "addr", r.Addr.String(), "version", r.Version,
+				"matrices", len(r.Matrices))
+			return r, nil
+		}
+		last = err
+	}
+	return nil, fmt.Errorf("rollcall: none of the %d nodes serves a routing interface: %w",
+		len(t.addrs), last)
+}
+
+// readMatrix reads one matrix's table and everything below it.
+func (p *Plugin) readMatrix(ctx context.Context, slot int,
+	matrices router.Table, m uint32) (RouterMatrix, error) {
+
+	mx := RouterMatrix{Number: m}
+	field := func(off uint32) (uint32, bool) {
+		c, ok := matrices.Field(m, off)
+		return uint32(c), ok
+	}
+
+	// The first field of a table is always addressable: m is inside the count
+	// the controller published, and offset zero is inside any step.
+	name, _ := field(router.OffMatrixName)
+
+	var err error
+	if mx.Name, err = p.readString(ctx, slot, name); err != nil {
+		return mx, err
+	}
+
+	levels, err := p.readTableAt(ctx, slot, matrices, m,
+		router.OffNumLevels, router.OffLevelBase, router.OffLevelStep)
+	if err != nil {
+		return mx, err
+	}
+	if mx.SrcAssocs, err = p.readTableAt(ctx, slot, matrices, m,
+		router.OffNumSrcAssocs, router.OffSrcAssocBase, router.OffSrcAssocStep); err != nil {
+		return mx, err
+	}
+	if mx.DstAssocs, err = p.readTableAt(ctx, slot, matrices, m,
+		router.OffNumDstAssocs, router.OffDstAssocBase, router.OffDstAssocStep); err != nil {
+		return mx, err
+	}
+
+	for _, f := range []struct {
+		off  uint32
+		into *RouterFile
+	}{
+		{router.OffAssocNames8File, &mx.AssocNames8},
+		{router.OffAssocNames32File, &mx.AssocNames},
+		{router.OffAssocNamesAltFile, &mx.AssocNamesAlt},
+		{router.OffAssocMappingsFile, &mx.AssocMappings},
+	} {
+		cmd, _ := field(f.off)
+		if *f.into, err = p.readFile(ctx, slot, cmd); err != nil {
+			return mx, err
+		}
+	}
+
+	if controller, ok := field(router.OffControllerNumber); ok {
+		n, err := p.readInt(ctx, slot, controller)
+		if err != nil {
+			return mx, err
+		}
+		mx.Controller = n
+	}
+
+	for v := uint32(1); v <= levels.Count; v++ {
+		level, err := p.readLevel(ctx, slot, levels, v)
+		if err != nil {
+			return mx, err
+		}
+		mx.Levels = append(mx.Levels, level)
+	}
+	return mx, nil
+}
+
+// readLevel reads one level's table.
+func (p *Plugin) readLevel(ctx context.Context, slot int,
+	levels router.Table, v uint32) (RouterLevel, error) {
+
+	lv := RouterLevel{Number: v}
+
+	// Offset zero again, so it is there.
+	name, _ := levels.Field(v, router.OffLevelName)
+
+	var err error
+	if lv.Name, err = p.readString(ctx, slot, uint32(name)); err != nil {
+		return lv, err
+	}
+
+	kind, _ := levels.Field(v, router.OffLevelType)
+	if lv.Kind, err = p.readInt(ctx, slot, uint32(kind)); err != nil {
+		return lv, err
+	}
+
+	if lv.Srcs, err = p.readTableAt(ctx, slot, levels, v,
+		router.OffNumSrcs, router.OffSrcBase, router.OffSrcStep); err != nil {
+		return lv, err
+	}
+	if lv.Dsts, err = p.readTableAt(ctx, slot, levels, v,
+		router.OffNumDsts, router.OffDstBase, router.OffDstStep); err != nil {
+		return lv, err
+	}
+
+	for _, f := range []struct {
+		off  uint32
+		into *RouterFile
+	}{
+		{router.OffSrcDstNames8File, &lv.Names8},
+		{router.OffSrcDstNames32File, &lv.Names},
+		{router.OffSrcDstNamesAltFile, &lv.NamesAlt},
+		{router.OffSrcDstMCDataFile, &lv.MCData},
+	} {
+		cmd, _ := levels.Field(v, f.off)
+		if *f.into, err = p.readFile(ctx, slot, uint32(cmd)); err != nil {
+			return lv, err
+		}
+	}
+	return lv, nil
+}
+
+// readTable reads a count, a base and a step, which is the shape every level
+// of this command space has.
+func (p *Plugin) readTable(ctx context.Context, slot int, count, base, step uint32) (router.Table, error) {
+	n, err := p.readUint(ctx, slot, count)
+	if err != nil {
+		return router.Table{}, err
+	}
+	b, err := p.readUint(ctx, slot, base)
+	if err != nil {
+		return router.Table{}, err
+	}
+	s, err := p.readUint(ctx, slot, step)
+	if err != nil {
+		return router.Table{}, err
+	}
+	return router.Table{Base: router.Command(b), Step: s, Count: n}, nil
+}
+
+// readTableAt reads a table whose three commands sit at offsets inside another
+// entity's table.
+func (p *Plugin) readTableAt(ctx context.Context, slot int, outer router.Table,
+	n uint32, countOff, baseOff, stepOff uint32) (router.Table, error) {
+
+	count, ok := outer.Field(n, countOff)
+	if !ok {
+		return router.Table{}, fmt.Errorf(
+			"rollcall: entity %d is outside the command space the router published", n)
+	}
+	base, _ := outer.Field(n, baseOff)
+	step, _ := outer.Field(n, stepOff)
+	return p.readTable(ctx, slot, uint32(count), uint32(base), uint32(step))
+}
+
+// readValue reads one command from a router node.
+func (p *Plugin) readValue(ctx context.Context, slot int, command uint32) (codec.Value, error) {
+	s, err := p.session(ctx, slot)
+	if err != nil {
+		return codec.Value{}, err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgGetValue, codec.GetValue{Command: command}.AppendTo(nil))
+	if err != nil {
+		return codec.Value{}, fmt.Errorf("rollcall: command %d: %w", command, err)
+	}
+	v, err := codec.DecodeValue(reply.Payload)
+	if err != nil {
+		return codec.Value{}, fmt.Errorf("rollcall: command %d: %w", command, err)
+	}
+	return v, nil
+}
+
+func (p *Plugin) readUint(ctx context.Context, slot int, command uint32) (uint32, error) {
+	n, err := p.readInt(ctx, slot, command)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 {
+		// A count or a base cannot be negative. A controller that says so is
+		// describing a command space that does not exist, and following it
+		// would read whatever happens to live at the wrapped-around number.
+		return 0, fmt.Errorf("rollcall: command %d returned %d, which cannot be a count or an address",
+			command, n)
+	}
+	return uint32(n), nil
+}
+
+func (p *Plugin) readInt(ctx context.Context, slot int, command uint32) (int32, error) {
+	v, err := p.readValue(ctx, slot, command)
+	if err != nil {
+		return 0, err
+	}
+	return v.Val, nil
+}
+
+func (p *Plugin) readString(ctx context.Context, slot int, command uint32) (string, error) {
+	v, err := p.readValue(ctx, slot, command)
+	if err != nil {
+		return "", err
+	}
+	return v.Text, nil
+}
+
+// readFile reads a filename and its checksum, which the controller carries as
+// Data Transfer Params rather than as a string.
+//
+// A command that names no file is not an error: a level with no alternate
+// names simply has none, and the empty value says so.
+func (p *Plugin) readFile(ctx context.Context, slot int, command uint32) (RouterFile, error) {
+	v, err := p.readValue(ctx, slot, command)
+	if err != nil {
+		return RouterFile{}, err
+	}
+	if len(v.Data) == 0 {
+		return RouterFile{}, nil
+	}
+
+	items, err := dtp.Decode(v.Data)
+	if err != nil {
+		return RouterFile{}, fmt.Errorf("rollcall: command %d: %w", command, err)
+	}
+
+	var f RouterFile
+	for _, it := range items {
+		switch it.Type {
+		case dtp.TypeString:
+			f.Name = it.Str
+		case dtp.TypeUint:
+			f.CRC = it.Uint
+		}
+	}
+	return f, nil
+}

--- a/internal/snell-rollcall/consumer/router_test.go
+++ b/internal/snell-rollcall/consumer/router_test.go
@@ -1,0 +1,463 @@
+package rollcall
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// The shape the vendor Centra has: two matrices, the first with two levels and
+// the second with three, ten of everything. Small enough to read in a test and
+// laid out by the same arithmetic a real controller uses.
+func testRouterShape() []fakeMatrix {
+	return []fakeMatrix{
+		{
+			name:      "R1 Matrix 1",
+			srcAssocs: 10, dstAssocs: 10,
+			levels: []fakeLevel{
+				{name: "R1M1 Level 1", srcs: 10, dsts: 10},
+				{name: "R1M1 Level 2", srcs: 10, dsts: 10},
+			},
+		},
+		{
+			name:      "R1 Matrix 2",
+			srcAssocs: 10, dstAssocs: 10,
+			levels: []fakeLevel{
+				{name: "R1M2 Level 1", srcs: 10, dsts: 10},
+				{name: "R1M2 Level 2", srcs: 10, dsts: 10},
+				{name: "R1M2 Level 3", srcs: 10, dsts: 10},
+			},
+		},
+	}
+}
+
+// routerHarness is a device whose port 2 is a router and whose other ports are
+// ordinary cards, which is the arrangement a controller presents.
+func routerHarness(t *testing.T, tweak func(*fakeRouter)) (*harness, *RouterInterface) {
+	t.Helper()
+
+	var fake *fakeRouter
+	h := newHarness(t, func(d *device) {
+		d.ports = 3
+		d.setMenu(1, testMenu())
+		fake = newFakeRouter(2, testRouterShape())
+		if tweak != nil {
+			tweak(fake)
+		}
+		d.routers[2] = fake
+		// The controller's bulk files are served by its own file service,
+		// which is how a client fetches names without a command per name.
+		for name, body := range fake.files {
+			d.files[name] = body
+		}
+	})
+
+	r, err := h.plugin.RouterAt(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("RouterAt: %v", err)
+	}
+	return h, r
+}
+
+func TestRouterModelIsReadByArithmetic(t *testing.T) {
+	_, r := routerHarness(t, nil)
+
+	if r.Version != router.VersionRouteErrors {
+		t.Errorf("interface version = %d", r.Version)
+	}
+	if r.Name != "Fake Router" {
+		t.Errorf("router name = %q", r.Name)
+	}
+	if len(r.Matrices) != 2 {
+		t.Fatalf("%d matrices, want 2", len(r.Matrices))
+	}
+
+	m1 := r.Matrices[0]
+	if m1.Name != "R1 Matrix 1" || m1.Controller != 1 {
+		t.Errorf("matrix 1 = %q controller %d", m1.Name, m1.Controller)
+	}
+	if len(m1.Levels) != 2 || len(r.Matrices[1].Levels) != 3 {
+		t.Errorf("levels = %d and %d, want 2 and 3",
+			len(m1.Levels), len(r.Matrices[1].Levels))
+	}
+	if m1.SrcAssocs.Count != 10 || m1.DstAssocs.Count != 10 {
+		t.Errorf("associations = %d/%d", m1.SrcAssocs.Count, m1.DstAssocs.Count)
+	}
+
+	lv := m1.Levels[0]
+	if lv.Name != "R1M1 Level 1" || lv.Srcs.Count != 10 || lv.Dsts.Count != 10 {
+		t.Errorf("level 1 = %q %d/%d", lv.Name, lv.Srcs.Count, lv.Dsts.Count)
+	}
+	// The steps are the table sizes the controller published, and reading them
+	// wrongly is what makes a client address the next entity's fields.
+	if lv.Srcs.Step != router.SrcTableSize || lv.Dsts.Step != router.DstTableSize {
+		t.Errorf("steps = %d/%d, want %d/%d",
+			lv.Srcs.Step, lv.Dsts.Step, router.SrcTableSize, router.DstTableSize)
+	}
+
+	// Every bulk file is named with a checksum, which is what makes caching
+	// possible at all.
+	if lv.Names8.Empty() || lv.Names.Empty() || lv.MCData.Empty() {
+		t.Errorf("level 1 published no names files: %+v", lv)
+	}
+	if m1.AssocMappings.Name != `RC_Files\AssocMap_1.dat` {
+		t.Errorf("mappings file = %q", m1.AssocMappings.Name)
+	}
+	if r.Salvos != 4 || r.Devices != 8 {
+		t.Errorf("salvos = %d, devices = %d", r.Salvos, r.Devices)
+	}
+}
+
+func TestFindRouterProbesEveryNode(t *testing.T) {
+	h, _ := routerHarness(t, nil)
+
+	// Nothing in a device list says which node is the panel driver: on the
+	// vendor Centra the matrices are their own nodes and neither serves the
+	// interface. Probing is safe because a node without one refuses.
+	r, err := h.plugin.FindRouter(context.Background())
+	if err != nil {
+		t.Fatalf("FindRouter: %v", err)
+	}
+	if r.Slot != 2 {
+		t.Errorf("found the router on slot %d, want 2", r.Slot)
+	}
+}
+
+func TestFindRouterOnADeviceWithNone(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.ports = 2 })
+
+	if _, err := h.plugin.FindRouter(context.Background()); err == nil {
+		t.Error("a frame of ordinary cards should have no routing interface")
+	}
+}
+
+func TestARouterNeedsTheLongStringGeneration(t *testing.T) {
+	// The command set exists only on the 32-bit generation: a matrix of any
+	// useful size needs more command numbers than the 16-bit field holds.
+	h := newHarness(t, func(d *device) {
+		d.services = codec.SvcMenus | codec.SvcControl | codec.SvcDisplay
+		d.ports = 2
+	})
+
+	_, err := h.plugin.RouterAt(context.Background(), 1)
+	if err == nil {
+		t.Fatal("a 16-bit session should have no routing interface")
+	}
+	if _, err := h.plugin.FindRouter(context.Background()); err == nil {
+		t.Error("FindRouter should have found nothing")
+	}
+}
+
+func TestReadingACrosspoint(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	xpt, err := h.plugin.Route(context.Background(), r, 1, 1, 3)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if xpt.Dest.Matrix != 1 || xpt.Dest.Level != 1 || xpt.Dest.Source != 3 {
+		t.Errorf("destination = %s", xpt.Dest)
+	}
+	if xpt.Source.Matrix != 1 || xpt.Source.Level != 1 || xpt.Source.Source != 1 {
+		t.Errorf("routed source = %s, want m1/l1/s1", xpt.Source)
+	}
+}
+
+func TestSettingACrosspoint(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 5}
+	reply, err := h.plugin.SetRoute(ctx, r, 1, 1, 2, src, 0)
+	if err != nil {
+		t.Fatalf("SetRoute: %v", err)
+	}
+
+	// The reply carries the value from *before* the change, with the result
+	// appended. A client that reads the new crosspoint out of it shows a stale
+	// one until something else refreshes.
+	if reply.Source.Source != 1 {
+		t.Errorf("the reply carried %s; it should carry what was routed before", reply.Source)
+	}
+	if !reply.HasResult || !reply.Result.OK() {
+		t.Errorf("result = %s present=%v", reply.Result, reply.HasResult)
+	}
+
+	// The new value is there when read again.
+	after, err := h.plugin.Route(ctx, r, 1, 1, 2)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if after.Source != src {
+		t.Errorf("after the set the destination has %s, want %s", after.Source, src)
+	}
+}
+
+func TestATallyFollowsTielines(t *testing.T) {
+	// Setting a source can read back as a different one: where a route crosses
+	// a tieline the controller reports the far end, because the pin is the
+	// final upstream source rather than what was asked for.
+	far := router.SourcePin{Matrix: 2, Level: 1, Source: 1}
+	h, r := routerHarness(t, func(f *fakeRouter) {
+		near := router.SourcePin{Matrix: 1, Level: 1, Source: 7}
+		f.tieline[near.Pack()] = far.Pack()
+	})
+	ctx := context.Background()
+
+	asked := router.SourcePin{Matrix: 1, Level: 1, Source: 7}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 1, 1, asked, 0); err != nil {
+		t.Fatalf("SetRoute: %v", err)
+	}
+
+	after, err := h.plugin.Route(ctx, r, 1, 1, 1)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if after.Source != far {
+		t.Errorf("tally = %s, want the upstream %s", after.Source, far)
+	}
+}
+
+func TestWatchingRoutes(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	changes := make(chan Crosspoint, 8)
+	if err := h.plugin.WatchRoutes(ctx, r, func(x Crosspoint) {
+		select {
+		case changes <- x:
+		default:
+		}
+	}); err != nil {
+		t.Fatalf("WatchRoutes: %v", err)
+	}
+
+	src := router.SourcePin{Matrix: 1, Level: 2, Source: 4}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 2, 6, src, 0); err != nil {
+		t.Fatalf("SetRoute: %v", err)
+	}
+
+	select {
+	case got := <-changes:
+		// The push carries a command number, and turning it back into a
+		// destination is the arithmetic in reverse.
+		if got.Dest.Matrix != 1 || got.Dest.Level != 2 || got.Dest.Source != 6 {
+			t.Errorf("tally named %s, want matrix 1 level 2 destination 6", got.Dest)
+		}
+		if got.Source != src {
+			t.Errorf("tally carried %s, want %s", got.Source, src)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no tally arrived")
+	}
+}
+
+func TestWatchingRoutesNeedsACallback(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	if err := h.plugin.WatchRoutes(context.Background(), r, nil); err == nil {
+		t.Error("watching without a callback should fail")
+	}
+}
+
+func TestAPushThatIsNotACrosspointIsIgnored(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	changes := make(chan Crosspoint, 8)
+	if err := h.plugin.WatchRoutes(ctx, r, func(x Crosspoint) {
+		select {
+		case changes <- x:
+		default:
+		}
+	}); err != nil {
+		t.Fatalf("WatchRoutes: %v", err)
+	}
+
+	// A router pushes on the same channel as everything else. A display line,
+	// a name, a value the model does not place: none of them is a crosspoint
+	// and none of them is a fault.
+	h.device.push(2, codec.MsgDispData, make([]byte, codec.DispSize))
+	h.device.push(2, codec.MsgRetValue, []byte{0x01})
+	name, err := codec.Value{Command: 121, Mode: codec.ModeString, Text: "x"}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	h.device.push(2, codec.MsgRetValue, name)
+
+	// Then a real one, which must still arrive: the barrier proves the three
+	// before it were taken and dropped rather than merely slow.
+	src := router.SourcePin{Matrix: 2, Level: 3, Source: 2}
+	if _, err := h.plugin.SetRoute(ctx, r, 2, 3, 4, src, 0); err != nil {
+		t.Fatalf("SetRoute: %v", err)
+	}
+
+	select {
+	case got := <-changes:
+		if got.Dest.Matrix != 2 || got.Dest.Level != 3 || got.Dest.Source != 4 {
+			t.Errorf("the first tally was %s, want matrix 2 level 3 destination 4", got.Dest)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no tally arrived")
+	}
+}
+
+func TestReadingEveryCrosspointOfALevel(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	xpts, err := h.plugin.Routes(context.Background(), r, 2, 2)
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	if len(xpts) != 10 {
+		t.Fatalf("%d crosspoints, want 10", len(xpts))
+	}
+	for i, x := range xpts {
+		if x.Dest.Source != uint16(i+1) {
+			t.Errorf("crosspoint %d names destination %d", i, x.Dest.Source)
+		}
+	}
+}
+
+func TestProtects(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	before, err := h.plugin.Protect(ctx, r, 1, 1, 1)
+	if err != nil {
+		t.Fatalf("Protect: %v", err)
+	}
+	if before.On {
+		t.Error("a destination starts unprotected")
+	}
+
+	got, err := h.plugin.SetProtect(ctx, r, 1, 1, 1, true, 42, false)
+	if err != nil {
+		t.Fatalf("SetProtect: %v", err)
+	}
+	if !got.On || got.ID != 42 {
+		t.Errorf("protect = %+v, want on with id 42", got)
+	}
+
+	// A protect with no id could never be released, and one past the
+	// configured range names a panel that cannot exist.
+	if _, err := h.plugin.SetProtect(ctx, r, 1, 1, 1, true, 0, false); err == nil {
+		t.Error("a protect with no panel id should be refused")
+	}
+	if _, err := h.plugin.SetProtect(ctx, r, 1, 1, 1, true, router.MaxProtectID+1, false); err == nil {
+		t.Error("a protect id past the configured range should be refused")
+	}
+}
+
+func TestFiringASalvo(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	if err := h.plugin.FireSalvo(ctx, r, 2); err != nil {
+		t.Fatalf("FireSalvo: %v", err)
+	}
+	if err := h.plugin.FireSalvo(ctx, r, 0); err == nil {
+		t.Error("salvo zero is not one of them")
+	}
+	if err := h.plugin.FireSalvo(ctx, r, r.Salvos+1); err == nil {
+		t.Error("a salvo past the end should be refused")
+	}
+
+	// Salvos arrived at a known interface version, and a controller older than
+	// that does not have the command at all.
+	old := *r
+	old.Version = router.VersionSalvos - 1
+	if err := h.plugin.FireSalvo(ctx, &old, 1); err == nil {
+		t.Error("an older interface has no salvos")
+	}
+}
+
+func TestAddressingWhatTheRouterDoesNotHave(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name                  string
+		matrix, level, entity uint32
+
+		// levelExists says whether the matrix and level themselves are real,
+		// which decides whether reading the whole level should work.
+		levelExists bool
+	}{
+		{name: "matrix zero", matrix: 0, level: 1, entity: 1},
+		{name: "a matrix past the end", matrix: 9, level: 1, entity: 1},
+		{name: "level zero", matrix: 1, level: 0, entity: 1},
+		{name: "a level past the end", matrix: 1, level: 9, entity: 1},
+		{name: "a destination past the end", matrix: 1, level: 1, entity: 99,
+			levelExists: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := h.plugin.Route(ctx, r, tc.matrix, tc.level, tc.entity); err == nil {
+				t.Error("reading it should fail")
+			}
+			if _, err := h.plugin.SetRoute(ctx, r, tc.matrix, tc.level, tc.entity,
+				router.SourcePin{Matrix: 1, Level: 1, Source: 1}, 0); err == nil {
+				t.Error("routing to it should fail")
+			}
+			if _, err := h.plugin.Protect(ctx, r, tc.matrix, tc.level, tc.entity); err == nil {
+				t.Error("reading its protect should fail")
+			}
+			if _, err := h.plugin.SetProtect(ctx, r, tc.matrix, tc.level, tc.entity,
+				true, 1, false); err == nil {
+				t.Error("protecting it should fail")
+			}
+			_, err := h.plugin.Routes(ctx, r, tc.matrix, tc.level)
+			if tc.levelExists && err != nil {
+				t.Errorf("reading a level that exists failed: %v", err)
+			}
+			if !tc.levelExists && err == nil {
+				t.Error("reading a level that does not exist should fail")
+			}
+		})
+	}
+}
+
+func TestARouteThatTheControllerRefuses(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	// A command the controller will not answer at all.
+	cmd, err := r.destCommand(1, 1, 1, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].refuse[cmd] = true
+	h.device.mu.Unlock()
+
+	ctx := context.Background()
+	if _, err := h.plugin.Route(ctx, r, 1, 1, 1); err == nil {
+		t.Error("a refused read should reach the caller")
+	}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 1, 1,
+		router.SourcePin{Matrix: 1, Level: 1, Source: 2}, 0); err == nil {
+		t.Error("a refused write should reach the caller")
+	}
+}
+
+func TestARouteWithAProtectID(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	// The id rides along with the pin in a two-entry array. It is a temporary
+	// override for local routing and rarely wanted, but a client that needs it
+	// has no other way to ask.
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 3}
+	if _, err := h.plugin.SetRoute(context.Background(), r, 1, 1, 4, src, 17); err != nil {
+		t.Fatalf("SetRoute with a protect id: %v", err)
+	}
+
+	after, err := h.plugin.Route(context.Background(), r, 1, 1, 4)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if after.Source != src {
+		t.Errorf("routed %s, want %s", after.Source, src)
+	}
+}

--- a/internal/snell-rollcall/consumer/routercoverage_test.go
+++ b/internal/snell-rollcall/consumer/routercoverage_test.go
@@ -1,0 +1,611 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/dtp"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// Discovery reads a few dozen commands and every one of them can be refused.
+// A controller that stops answering half way through is not hypothetical: it
+// is what a unit under load, or one being reconfigured, looks like.
+
+// tryRouter builds a harness and reads the router without failing the test.
+func tryRouter(t *testing.T, tweak func(*fakeRouter)) (*harness, *RouterInterface, error) {
+	t.Helper()
+
+	h := newHarness(t, func(d *device) {
+		d.ports = 3
+		f := newFakeRouter(2, testRouterShape())
+		if tweak != nil {
+			tweak(f)
+		}
+		d.routers[2] = f
+		for name, body := range f.files {
+			d.files[name] = body
+		}
+	})
+	r, err := h.plugin.RouterAt(context.Background(), 2)
+	return h, r, err
+}
+
+// discoveryCommands are the commands a full read touches, worked out the same
+// way the reader works them out.
+func discoveryCommands() map[string]uint32 {
+	const (
+		matrixBase = 121
+		matrixStep = router.MatrixTableSize
+	)
+	out := map[string]uint32{}
+
+	// The root commands discovery reads. The others in the table are written
+	// rather than read — make a route, fire a salvo, fetch a track template —
+	// so refusing one changes nothing about reading the model.
+	for _, cmd := range []router.Command{
+		router.CmdInterfaceVersion, router.CmdRouterName,
+		router.CmdNumMatrices, router.CmdMatrixBase, router.CmdMatrixStep,
+		router.CmdNumCategories, router.CmdCategoryBase, router.CmdCategoryStep,
+		router.CmdNumSalvos, router.CmdSalvoNames8File, router.CmdSalvoNames32File,
+		router.CmdNumDevices, router.CmdDeviceNamesFile,
+	} {
+		out[fmt.Sprintf("root command %d", cmd)] = uint32(cmd)
+	}
+	for off := uint32(0); off < router.MatrixTableSize; off++ {
+		out[fmt.Sprintf("matrix 1 field %d", off)] = matrixBase + off
+	}
+
+	// The level table's own base is what the matrix table pointed at, and the
+	// fake lays the first one out immediately after the categories.
+	levelBase := uint32(matrixBase + 2*matrixStep + 32)
+	for off := uint32(0); off < router.LevelTableSize; off++ {
+		out[fmt.Sprintf("level 1 field %d", off)] = levelBase + off
+	}
+	return out
+}
+
+func TestDiscoveryGivesUpWhenACommandIsRefused(t *testing.T) {
+	for name, cmd := range discoveryCommands() {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := tryRouter(t, func(f *fakeRouter) { f.refuse[cmd] = true })
+			if err == nil {
+				t.Errorf("command %d was refused and the read succeeded anyway", cmd)
+			}
+		})
+	}
+}
+
+func TestDiscoveryRefusesACountThatCannotBeOne(t *testing.T) {
+	// A count or a base cannot be negative. Following one would read whatever
+	// happens to live at the wrapped-around command number.
+	_, _, err := tryRouter(t, func(f *fakeRouter) {
+		f.num(uint32(router.CmdNumMatrices), -1)
+	})
+	if err == nil {
+		t.Error("a negative matrix count should be refused")
+	}
+}
+
+func TestDiscoveryWithAFileNameItCannotDecode(t *testing.T) {
+	_, _, err := tryRouter(t, func(f *fakeRouter) {
+		// Data that is not Data Transfer Params at all.
+		f.data(uint32(router.CmdSalvoNames8File), []byte{0xFF, 0xFF, 0xFF})
+	})
+	if err == nil {
+		t.Error("a filename that will not decode should be reported")
+	}
+}
+
+func TestDiscoverySkipsWhatTheVersionSaysIsAbsent(t *testing.T) {
+	// Salvos and device names arrived at known interface versions. On an older
+	// controller the commands do not exist, and asking would fire a compliance
+	// event for something the version already said.
+	_, r, err := tryRouter(t, func(f *fakeRouter) {
+		f.num(uint32(router.CmdInterfaceVersion), router.VersionProtectID16)
+		f.refuse[uint32(router.CmdNumSalvos)] = true
+		f.refuse[uint32(router.CmdNumDevices)] = true
+	})
+	if err != nil {
+		t.Fatalf("an older interface should still read: %v", err)
+	}
+	if r.Salvos != 0 || r.Devices != 0 {
+		t.Errorf("salvos = %d devices = %d, want neither", r.Salvos, r.Devices)
+	}
+}
+
+func TestARouterThatPublishesAStepSmallerThanItsTable(t *testing.T) {
+	// A controller whose step is smaller than the table it documents has
+	// entities overlapping in the command space. Reading past the step would
+	// read the next entity's fields rather than this one's, so the reader
+	// stops instead.
+	h, r, err := tryRouter(t, func(f *fakeRouter) {
+		// Level 1 of matrix 1: source step of one, so only the first field of
+		// each source is addressable.
+		levelBase := uint32(121 + 2*router.MatrixTableSize + 32)
+		f.num(levelBase+router.OffSrcStep, 1)
+	})
+	if err != nil {
+		t.Fatalf("RouterAt: %v", err)
+	}
+
+	lv, err := r.Level(1, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	lv.Names = RouterFile{}
+	lv.Names8 = RouterFile{}
+
+	// The long names live at offset one, which is past the step, so nothing
+	// can be read and the answer is empty rather than wrong.
+	names, err := h.plugin.LevelNames(context.Background(), r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	if len(names.Srcs) != 0 {
+		t.Errorf("%d source names came back from a table that cannot address them", len(names.Srcs))
+	}
+
+	// Destinations are addressable, so those still arrive.
+	if len(names.Dsts) != 10 {
+		t.Errorf("%d destination names, want 10", len(names.Dsts))
+	}
+}
+
+func TestARouterWhoseDestinationStepIsTooSmall(t *testing.T) {
+	h, r, err := tryRouter(t, func(f *fakeRouter) {
+		levelBase := uint32(121 + 2*router.MatrixTableSize + 32)
+		f.num(levelBase+router.OffDstStep, 1)
+	})
+	if err != nil {
+		t.Fatalf("RouterAt: %v", err)
+	}
+
+	lv, err := r.Level(1, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	lv.Names = RouterFile{}
+	lv.Names8 = RouterFile{}
+
+	names, err := h.plugin.LevelNames(context.Background(), r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	if len(names.Dsts) != 0 {
+		t.Errorf("%d destination names came back", len(names.Dsts))
+	}
+
+	// And the routed source is past the step too, so a route cannot even be
+	// addressed.
+	if _, err := h.plugin.Route(context.Background(), r, 1, 1, 1); err == nil {
+		t.Error("a destination whose fields are past its step should not be addressable")
+	}
+}
+
+func TestRoutingWhenTheDeviceHasGoneAway(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	if err := h.plugin.Disconnect(); err != nil {
+		t.Fatalf("Disconnect: %v", err)
+	}
+
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 2}
+	if _, err := h.plugin.Route(ctx, r, 1, 1, 1); err == nil {
+		t.Error("reading a route without a connection should fail")
+	}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 1, 1, src, 0); err == nil {
+		t.Error("setting a route without a connection should fail")
+	}
+	if _, err := h.plugin.Protect(ctx, r, 1, 1, 1); err == nil {
+		t.Error("reading a protect without a connection should fail")
+	}
+	if _, err := h.plugin.SetProtect(ctx, r, 1, 1, 1, true, 4, false); err == nil {
+		t.Error("setting a protect without a connection should fail")
+	}
+	if err := h.plugin.FireSalvo(ctx, r, 1); err == nil {
+		t.Error("firing a salvo without a connection should fail")
+	}
+	if err := h.plugin.WatchRoutes(ctx, r, func(Crosspoint) {}); err == nil {
+		t.Error("watching without a connection should fail")
+	}
+	if _, err := h.plugin.LevelNames(ctx, r, 1, 1, router.NameWidth32); err == nil {
+		t.Error("reading names without a connection should fail")
+	}
+	if _, err := h.plugin.Mappings(ctx, r, 1); err == nil {
+		t.Error("reading mappings without a connection should fail")
+	}
+	if _, err := h.plugin.RouterAt(ctx, 2); err == nil {
+		t.Error("reading the interface without a connection should fail")
+	}
+	if _, err := h.plugin.FindRouter(ctx); err == nil {
+		t.Error("finding a router without a connection should fail")
+	}
+}
+
+func TestARouteReplyThatWillNotDecode(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	// A controller answering a route with something that is not Data Transfer
+	// Params at all.
+	cmd, err := r.destCommand(1, 1, 1, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].data(cmd, []byte{0xFF, 0xFF})
+	h.device.mu.Unlock()
+
+	if _, err := h.plugin.Route(ctx, r, 1, 1, 1); err == nil {
+		t.Error("a crosspoint that will not decode should be reported")
+	}
+}
+
+func TestARouteTheControllerRefusesToMake(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	// The result code is what says whether it worked, and a client that
+	// ignores it believes a route it did not get.
+	cmd, err := r.destCommand(1, 1, 1, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].results = map[uint32]router.RouteResult{cmd: router.RouteInhibited}
+	h.device.mu.Unlock()
+
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 2}
+	got, err := h.plugin.SetRoute(context.Background(), r, 1, 1, 1, src, 0)
+	if err == nil {
+		t.Fatal("an inhibited route should be reported as one")
+	}
+	if got.Result != router.RouteInhibited {
+		t.Errorf("result = %s, want inhibited", got.Result)
+	}
+}
+
+func TestASalvoTheControllerRefuses(t *testing.T) {
+	h, r := routerHarness(t, func(f *fakeRouter) {
+		f.refuse[uint32(router.CmdFireSalvo)] = true
+	})
+
+	if err := h.plugin.FireSalvo(context.Background(), r, 1); err == nil {
+		t.Error("a refused salvo should reach the caller")
+	}
+}
+
+func TestAProtectTheControllerRefuses(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	cmd, err := r.destCommand(1, 1, 2, router.OffDestProtect)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].refuse[cmd] = true
+	h.device.mu.Unlock()
+
+	ctx := context.Background()
+	if _, err := h.plugin.Protect(ctx, r, 1, 1, 2); err == nil {
+		t.Error("a refused protect read should reach the caller")
+	}
+	if _, err := h.plugin.SetProtect(ctx, r, 1, 1, 2, true, 9, false); err == nil {
+		t.Error("a refused protect write should reach the caller")
+	}
+}
+
+func TestReadingALevelThatStopsPartWay(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	cmd, err := r.destCommand(1, 1, 4, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].refuse[cmd] = true
+	h.device.mu.Unlock()
+
+	// What was read before the failure comes back with it: three destinations
+	// are better than none to a caller drawing a panel.
+	got, err := h.plugin.Routes(context.Background(), r, 1, 1)
+	if err == nil {
+		t.Fatal("a level that stops part way should report it")
+	}
+	if len(got) != 3 {
+		t.Errorf("%d crosspoints came back with the error, want the 3 that were read", len(got))
+	}
+}
+
+func TestWatchingWhenTheBackChannelIsRefused(t *testing.T) {
+	h, r := routerHarness(t, func(f *fakeRouter) {})
+
+	h.device.mu.Lock()
+	h.device.refuse[codec.MsgBkChnReady] = true
+	h.device.mu.Unlock()
+
+	if err := h.plugin.WatchRoutes(context.Background(), r, func(Crosspoint) {}); err == nil {
+		t.Error("a refused back channel should reach the caller")
+	}
+}
+
+func TestWatchingStopsWhenTheLinkDoes(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	done := make(chan struct{})
+	if err := h.plugin.WatchRoutes(context.Background(), r, func(Crosspoint) {
+		close(done)
+	}); err != nil {
+		t.Fatalf("WatchRoutes: %v", err)
+	}
+
+	// The device goes away. The watcher must end rather than spin on a dead
+	// session, and nothing may be delivered afterwards.
+	h.device.close()
+
+	select {
+	case <-done:
+		t.Error("a crosspoint was delivered after the device went away")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestCrosspointDecoding(t *testing.T) {
+	dest := router.SourcePin{Matrix: 1, Level: 1, Source: 1}
+
+	// A destination with nothing routed to it and nothing to report.
+	got, err := decodeCrosspoint(codec.Value{}, dest)
+	if err != nil {
+		t.Fatalf("an empty value: %v", err)
+	}
+	if got.Source.Source != 0 || got.HasResult {
+		t.Errorf("an empty value decoded to %+v", got)
+	}
+
+	// A controller may answer with the array form it accepts on a write.
+	pin := router.SourcePin{Matrix: 2, Level: 1, Source: 6}
+	data, err := dtp.Encode(dtp.Params{dtp.Uints(pin.Pack()), dtp.Uint(uint32(router.RouteOK))}, false)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err = decodeCrosspoint(codec.Value{Mode: codec.ModeData, Data: data}, dest)
+	if err != nil {
+		t.Fatalf("the array form: %v", err)
+	}
+	if got.Source != pin || !got.HasResult {
+		t.Errorf("the array form decoded to %+v, want %s", got, pin)
+	}
+
+	// An array that is there but empty says nothing about the source.
+	data, err = dtp.Encode(dtp.Params{dtp.Uints()}, false)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err = decodeCrosspoint(codec.Value{Mode: codec.ModeData, Data: data}, dest)
+	if err != nil {
+		t.Fatalf("an empty array: %v", err)
+	}
+	if got.Source.Source != 0 {
+		t.Errorf("an empty array decoded to %s", got.Source)
+	}
+}
+
+func TestSourceCommandsOutsideTheirRange(t *testing.T) {
+	_, r := routerHarness(t, nil)
+
+	if _, err := r.srcCommand(1, 1, 99, router.OffSrcName8); err == nil {
+		t.Error("a source past the end should not be addressable")
+	}
+	if _, err := r.srcCommand(9, 1, 1, router.OffSrcName8); err == nil {
+		t.Error("a source on a matrix past the end should not be addressable")
+	}
+}
+
+func TestRepliesThatWillNotDecode(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	routed, err := r.destCommand(1, 1, 5, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	prot, err := r.destCommand(1, 1, 5, router.OffDestProtect)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+
+	h.device.mu.Lock()
+	h.device.routers[2].garble[routed] = true
+	h.device.routers[2].garble[prot] = true
+	h.device.mu.Unlock()
+
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 2}
+	if _, err := h.plugin.Route(ctx, r, 1, 1, 5); err == nil {
+		t.Error("a garbled read should be an error, not a zero crosspoint")
+	}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 1, 5, src, 0); err == nil {
+		t.Error("a garbled set reply should be an error")
+	}
+	if _, err := h.plugin.Protect(ctx, r, 1, 1, 5); err == nil {
+		t.Error("a garbled protect read should be an error")
+	}
+	if _, err := h.plugin.SetProtect(ctx, r, 1, 1, 5, true, 3, false); err == nil {
+		t.Error("a garbled protect reply should be an error")
+	}
+}
+
+func TestASetReplyThatIsNotACrosspoint(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	// The value decodes but its data is not Data Transfer Params, so there is
+	// no crosspoint in it.
+	cmd, err := r.destCommand(1, 2, 3, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.routers[2].results = map[uint32]router.RouteResult{}
+	h.device.routers[2].badReply = map[uint32]bool{cmd: true}
+	h.device.mu.Unlock()
+
+	src := router.SourcePin{Matrix: 1, Level: 2, Source: 2}
+	if _, err := h.plugin.SetRoute(context.Background(), r, 1, 2, 3, src, 0); err == nil {
+		t.Error("a set answered with something that is not a crosspoint should fail")
+	}
+}
+
+func TestAFileCommandThatNamesNothing(t *testing.T) {
+	// A level with no alternate names simply has none, and an empty value says
+	// so rather than failing.
+	_, r, err := tryRouter(t, func(f *fakeRouter) {
+		f.data(uint32(router.CmdDeviceNamesFile), nil)
+	})
+	if err != nil {
+		t.Fatalf("RouterAt: %v", err)
+	}
+	if !r.DeviceNames.Empty() {
+		t.Errorf("device names = %+v, want nothing", r.DeviceNames)
+	}
+}
+
+func TestANamesFileTooShortForItsLevel(t *testing.T) {
+	h, r := routerHarness(t, nil)
+
+	lv, err := r.Level(1, 1)
+	if err != nil {
+		t.Fatalf("Level: %v", err)
+	}
+	h.device.mu.Lock()
+	h.device.files[lv.Names.Name] = []byte{0x01, 0x02}
+	h.device.mu.Unlock()
+
+	// Too short to hold the names the level declares. Falling back to one
+	// command per name is what is left, and it works.
+	names, err := h.plugin.LevelNames(context.Background(), r, 1, 1, router.NameWidth32)
+	if err != nil {
+		t.Fatalf("LevelNames: %v", err)
+	}
+	if got := names.Src(1); got != "matrix1 level1 source1" {
+		t.Errorf("source 1 = %q", got)
+	}
+}
+
+func TestATallyPushThatWillNotDecode(t *testing.T) {
+	h, r := routerHarness(t, nil)
+	ctx := context.Background()
+
+	changes := make(chan Crosspoint, 4)
+	if err := h.plugin.WatchRoutes(ctx, r, func(x Crosspoint) {
+		select {
+		case changes <- x:
+		default:
+		}
+	}); err != nil {
+		t.Fatalf("WatchRoutes: %v", err)
+	}
+
+	// A push on a destination's own command whose data is not Data Transfer
+	// Params. It is a crosspoint by its number and not one by its content, and
+	// neither delivering nonsense nor stopping is right: it is dropped.
+	cmd, err := r.destCommand(1, 1, 8, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	bad, err := codec.Value{Command: cmd, Mode: codec.ModeData, Data: []byte{0xFF, 0xFF}}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	h.device.push(2, codec.MsgRetValue, bad)
+
+	// A real change afterwards still arrives.
+	src := router.SourcePin{Matrix: 1, Level: 1, Source: 9}
+	if _, err := h.plugin.SetRoute(ctx, r, 1, 1, 9, src, 0); err != nil {
+		t.Fatalf("SetRoute: %v", err)
+	}
+
+	select {
+	case got := <-changes:
+		if got.Dest.Source != 9 {
+			t.Errorf("the first tally named destination %d, want 9", got.Dest.Source)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no tally arrived")
+	}
+}
+
+func TestAMatrixStepSmallerThanItsTable(t *testing.T) {
+	// A controller whose matrix step is smaller than the table it documents has
+	// matrices overlapping in the command space. Reading past the step would
+	// read the next matrix's fields, so discovery stops rather than reporting
+	// a model built from the wrong numbers.
+	_, _, err := tryRouter(t, func(f *fakeRouter) {
+		f.num(uint32(router.CmdMatrixStep), 1)
+	})
+	if err == nil {
+		t.Error("a matrix step smaller than the matrix table should be refused")
+	}
+}
+
+func TestATallyThatCannotBeAcknowledged(t *testing.T) {
+	// Every push is a request and the acknowledgement is what asks for the
+	// next, so a client that cannot acknowledge is a client that will hear
+	// nothing more. The watcher ends rather than spinning.
+	h, blocked := newBlockedHarness(t, func(d *device) {
+		d.ports = 3
+		f := newFakeRouter(2, testRouterShape())
+		d.routers[2] = f
+		for name, body := range f.files {
+			d.files[name] = body
+		}
+	})
+
+	ctx := context.Background()
+	r, err := h.plugin.RouterAt(ctx, 2)
+	if err != nil {
+		t.Fatalf("RouterAt: %v", err)
+	}
+
+	seen := make(chan struct{}, 4)
+	if err := h.plugin.WatchRoutes(ctx, r, func(Crosspoint) {
+		seen <- struct{}{}
+	}); err != nil {
+		t.Fatalf("WatchRoutes: %v", err)
+	}
+
+	// The socket goes away after the push has been sent but before it can be
+	// answered.
+	cmd, err := r.destCommand(1, 1, 2, router.OffDestRoutedSrc)
+	if err != nil {
+		t.Fatalf("destCommand: %v", err)
+	}
+	pin := router.SourcePin{Matrix: 1, Level: 1, Source: 6}
+	data, err := dtp.Encode(dtp.Params{dtp.Uint(pin.Pack())}, false)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	payload, err := codec.Value{Command: cmd, Mode: codec.ModeData, Data: data}.AppendTo(nil)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	(*blocked).failing.Store(true)
+	h.device.push(2, codec.MsgRetValue, payload)
+
+	select {
+	case <-seen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the change was never delivered")
+	}
+
+	// Nothing more can arrive, because nothing more will be asked for.
+	h.device.push(2, codec.MsgRetValue, payload)
+	select {
+	case <-seen:
+		t.Error("a second push was taken after the first could not be acknowledged")
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/snell-rollcall/consumer/routerdevice_test.go
+++ b/internal/snell-rollcall/consumer/routerdevice_test.go
@@ -1,0 +1,392 @@
+package rollcall
+
+import (
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/dtp"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// A fake router controller, laid out the way the vendor Centra lays itself
+// out: a root table at command 100, matrices at 121 with a step of 15, and
+// everything below found by the arithmetic the controller publishes rather than
+// by numbers written here. Building it that way is the point — a reader that
+// gets an offset wrong fails against this for the same reason it would fail
+// against the real thing.
+//
+// Its two deliberate behaviours are the ones a client gets wrong: the reply to
+// a route set carries the value from before the set, and the new value arrives
+// afterwards as a back-channel push.
+
+// fakeRouter is a routing interface served on one port.
+type fakeRouter struct {
+	port uint8
+
+	version  uint32
+	name     string
+	matrices []fakeMatrix
+
+	salvos  uint32
+	devices uint32
+
+	// values is the command space: every command the interface answers.
+	values map[uint32]codec.Value
+
+	// routed maps a routed-source command to what is on it.
+	routed map[uint32]router.SourcePin
+
+	// tieline routes a source pin somewhere else, so the tally reports a
+	// different pin from the one that was written — which is what a real
+	// controller does when a route crosses a tieline.
+	tieline map[uint32]uint32
+
+	// refuse is a command that answers NACK, for the paths that give up.
+	refuse map[uint32]bool
+
+	// badReply makes a set answer with a value whose data is not Data Transfer
+	// Params, so it decodes as a value and holds no crosspoint.
+	badReply map[uint32]bool
+
+	// garble makes a command answer with a payload that is not the structure
+	// it claims to be, which is what a unit with a firmware fault looks like.
+	garble map[uint32]bool
+
+	// results are the route results a destination's next set answers with,
+	// for the refusals a controller expresses in the result code rather than
+	// by refusing the message.
+	results map[uint32]router.RouteResult
+
+	// files are the bulk files this controller publishes, by the name it
+	// publishes them under. The checksums it advertises are computed from
+	// these, so a client that verifies one is verifying the real thing.
+	files map[string][]byte
+}
+
+type fakeMatrix struct {
+	name   string
+	levels []fakeLevel
+
+	srcAssocs uint32
+	dstAssocs uint32
+}
+
+type fakeLevel struct {
+	name string
+	srcs uint32
+	dsts uint32
+}
+
+// newFakeRouter builds a controller with the given shape and lays out its
+// command space.
+func newFakeRouter(port uint8, matrices []fakeMatrix) *fakeRouter {
+	r := &fakeRouter{
+		port:     port,
+		version:  router.VersionRouteErrors,
+		name:     "Fake Router",
+		matrices: matrices,
+		salvos:   4,
+		devices:  8,
+		values:   make(map[uint32]codec.Value),
+		routed:   make(map[uint32]router.SourcePin),
+		tieline:  make(map[uint32]uint32),
+		refuse:   make(map[uint32]bool),
+		garble:   make(map[uint32]bool),
+		files:    make(map[string][]byte),
+	}
+	r.layout()
+	return r
+}
+
+// layout fills the command space, following the same arithmetic a client uses
+// to read it back.
+func (r *fakeRouter) layout() {
+	const (
+		matrixBase = 121
+		matrixStep = router.MatrixTableSize
+	)
+
+	r.num(uint32(router.CmdInterfaceVersion), int32(r.version))
+	r.str(uint32(router.CmdRouterName), r.name)
+	r.num(uint32(router.CmdNumMatrices), int32(len(r.matrices)))
+	r.num(uint32(router.CmdMatrixBase), matrixBase)
+	r.num(uint32(router.CmdMatrixStep), matrixStep)
+
+	categoryBase := uint32(matrixBase + len(r.matrices)*matrixStep)
+	r.num(uint32(router.CmdNumCategories), 0)
+	r.num(uint32(router.CmdCategoryBase), int32(categoryBase))
+	r.num(uint32(router.CmdCategoryStep), 6)
+
+	r.num(uint32(router.CmdNumSalvos), int32(r.salvos))
+	r.file(uint32(router.CmdSalvoNames8File), `RC_Files\SalvoNames_8.dat`, 0x1111)
+	r.file(uint32(router.CmdSalvoNames32File), `RC_Files\SalvoNames_32.dat`, 0x2222)
+	r.data(uint32(router.CmdFireSalvo), nil)
+	r.num(uint32(router.CmdNumDevices), int32(r.devices))
+	r.file(uint32(router.CmdDeviceNamesFile), `RC_Files\DeviceNames.dat`, 0x3333)
+
+	// Levels and entities are laid out after the matrix tables, each block
+	// following the last, exactly as a controller allocates them.
+	next := categoryBase + 32
+
+	for i := range r.matrices {
+		m := &r.matrices[i]
+		n := uint32(i + 1)
+		base := uint32(matrixBase) + (n-1)*matrixStep
+
+		levelBase := next
+		next += uint32(len(m.levels)) * router.LevelTableSize
+
+		r.str(base+router.OffMatrixName, m.name)
+		r.num(base+router.OffNumLevels, int32(len(m.levels)))
+		r.num(base+router.OffLevelBase, int32(levelBase))
+		r.num(base+router.OffLevelStep, router.LevelTableSize)
+		r.num(base+router.OffNumSrcAssocs, int32(m.srcAssocs))
+		r.num(base+router.OffSrcAssocBase, int32(next))
+		r.num(base+router.OffSrcAssocStep, 5)
+		next += m.srcAssocs * 5
+		r.num(base+router.OffNumDstAssocs, int32(m.dstAssocs))
+		r.num(base+router.OffDstAssocBase, int32(next))
+		r.num(base+router.OffDstAssocStep, 5)
+		next += m.dstAssocs * 5
+
+		r.names(base+router.OffAssocNames8File,
+			fmt.Sprintf(`RC_Files\AssocNames_%d_8.dat`, n), router.NameWidth8,
+			namesOf("M%dSA%d", "M%dDA%d", n, m.srcAssocs, m.dstAssocs))
+		r.names(base+router.OffAssocNames32File,
+			fmt.Sprintf(`RC_Files\AssocNames_%d_32.dat`, n), router.NameWidth32,
+			namesOf("matrix%d source assoc %d", "matrix%d dest assoc %d", n, m.srcAssocs, m.dstAssocs))
+		r.names(base+router.OffAssocNamesAltFile,
+			fmt.Sprintf(`RC_Files\AssocNames_%d_alt.dat`, n), router.NameWidth32,
+			namesOf("alt-sa%d-%d", "alt-da%d-%d", n, m.srcAssocs, m.dstAssocs))
+		r.num(base+router.OffControllerNumber, 1)
+		r.mappings(base+router.OffAssocMappingsFile,
+			fmt.Sprintf(`RC_Files\AssocMap_%d.dat`, n),
+			len(m.levels), m.srcAssocs, m.dstAssocs)
+
+		for j := range m.levels {
+			lv := &m.levels[j]
+			v := uint32(j + 1)
+			lbase := levelBase + (v-1)*router.LevelTableSize
+
+			srcBase := next
+			next += lv.srcs * router.SrcTableSize
+			dstBase := next
+			next += lv.dsts * router.DstTableSize
+
+			r.str(lbase+router.OffLevelName, lv.name)
+			r.num(lbase+router.OffLevelType, 0)
+			r.num(lbase+router.OffNumSrcs, int32(lv.srcs))
+			r.num(lbase+router.OffSrcBase, int32(srcBase))
+			r.num(lbase+router.OffSrcStep, router.SrcTableSize)
+			r.num(lbase+router.OffNumDsts, int32(lv.dsts))
+			r.num(lbase+router.OffDstBase, int32(dstBase))
+			r.num(lbase+router.OffDstStep, router.DstTableSize)
+			// The names in the file are the same ones the per-entity
+			// commands below return, so a client that falls back to those
+			// gets the same answer more slowly.
+			r.names(lbase+router.OffSrcDstNames8File,
+				fmt.Sprintf(`RC_Files\SrcDstNames_%d_%d_8.dat`, n, v), router.NameWidth8,
+				levelNames("M%dL%dS%d", "M%dL%dD%d", n, v, lv.srcs, lv.dsts))
+			r.names(lbase+router.OffSrcDstNames32File,
+				fmt.Sprintf(`RC_Files\SrcDstNames_%d_%d_32.dat`, n, v), router.NameWidth32,
+				levelNames("matrix%d level%d source%d", "matrix%d level%d dest%d",
+					n, v, lv.srcs, lv.dsts))
+			r.names(lbase+router.OffSrcDstNamesAltFile,
+				fmt.Sprintf(`RC_Files\SrcDstNames_%d_%d_alt.dat`, n, v), router.NameWidth32,
+				levelNames("alt-s%d-%d-%d", "alt-d%d-%d-%d", n, v, lv.srcs, lv.dsts))
+			r.file(lbase+router.OffSrcDstMCDataFile,
+				fmt.Sprintf(`RC_Files\SrcDstMCData_%d_%d.dat`, n, v), 0x8000+n*16+v)
+
+			for s := uint32(1); s <= lv.srcs; s++ {
+				sb := srcBase + (s-1)*router.SrcTableSize
+				r.str(sb+router.OffSrcName8, fmt.Sprintf("M%dL%dS%d", n, v, s))
+				r.str(sb+router.OffSrcName32, fmt.Sprintf("matrix%d level%d source%d", n, v, s))
+				r.str(sb+router.OffSrcAltName, fmt.Sprintf("alt-s%d", s))
+			}
+			for d := uint32(1); d <= lv.dsts; d++ {
+				db := dstBase + (d-1)*router.DstTableSize
+				r.str(db+router.OffDestName8, fmt.Sprintf("M%dL%dD%d", n, v, d))
+				r.str(db+router.OffDestName32, fmt.Sprintf("matrix%d level%d dest%d", n, v, d))
+				r.str(db+router.OffDestAltName, fmt.Sprintf("alt-d%d", d))
+
+				// Every destination starts with source one of its own level
+				// routed to it, which is what a controller comes up with.
+				pin := router.SourcePin{Matrix: uint8(n), Level: uint8(v), Source: 1}
+				r.routed[db+router.OffDestRoutedSrc] = pin
+				r.data(db+router.OffDestRoutedSrc, mustDTP(dtp.Params{dtp.Uint(pin.Pack())}))
+
+				r.values[db+router.OffDestProtect] = codec.Value{
+					Command: db + router.OffDestProtect,
+					Mode:    codec.ModeValue | codec.ModeString,
+				}
+				r.data(db+router.OffDestMCSrcs, nil)
+				r.data(db+router.OffDestMCProtects, nil)
+				r.data(db+router.OffDestMCProtect, nil)
+			}
+		}
+	}
+}
+
+func (r *fakeRouter) num(cmd uint32, v int32) {
+	r.values[cmd] = codec.Value{Command: cmd, Mode: codec.ModeValue, Val: v}
+}
+
+func (r *fakeRouter) str(cmd uint32, s string) {
+	r.values[cmd] = codec.Value{Command: cmd, Mode: codec.ModeString, Text: s}
+}
+
+func (r *fakeRouter) data(cmd uint32, b []byte) {
+	r.values[cmd] = codec.Value{Command: cmd, Mode: codec.ModeData, Data: b}
+}
+
+// file publishes a filename and its checksum as Data Transfer Params, which is
+// how a controller names every bulk file.
+func (r *fakeRouter) file(cmd uint32, name string, crc uint32) {
+	r.data(cmd, mustDTP(dtp.Params{dtp.String(name), dtp.Uint(crc)}))
+}
+
+// names publishes a names file: the bytes go in the file service, and the
+// checksum the controller advertises is computed from them.
+func (r *fakeRouter) names(cmd uint32, path string, width int, nf router.NamesFile) {
+	nf.Width = width
+	body, err := nf.AppendTo(nil)
+	if err != nil {
+		panic(err)
+	}
+	r.files[path] = body
+	r.file(cmd, path, nf.CRC())
+}
+
+// mappings publishes an association mappings file, where association n reaches
+// entity n on every level.
+func (r *fakeRouter) mappings(cmd uint32, path string, levels int, srcs, dsts uint32) {
+	mf := router.MappingsFile{Levels: levels}
+	for i := uint32(1); i <= srcs; i++ {
+		row := make([]uint32, levels)
+		for j := range row {
+			row[j] = i
+		}
+		mf.Srcs = append(mf.Srcs, row)
+	}
+	for i := uint32(1); i <= dsts; i++ {
+		row := make([]uint32, levels)
+		for j := range row {
+			row[j] = i
+		}
+		mf.Dsts = append(mf.Dsts, row)
+	}
+
+	r.files[path] = mf.AppendTo(nil)
+	r.file(cmd, path, mf.CRC())
+}
+
+// levelNames builds the source and destination names of one level.
+func levelNames(srcFmt, dstFmt string, matrix, level, srcs, dsts uint32) router.NamesFile {
+	var nf router.NamesFile
+	for i := uint32(1); i <= srcs; i++ {
+		nf.Srcs = append(nf.Srcs, fmt.Sprintf(srcFmt, matrix, level, i))
+	}
+	for i := uint32(1); i <= dsts; i++ {
+		nf.Dsts = append(nf.Dsts, fmt.Sprintf(dstFmt, matrix, level, i))
+	}
+	return nf
+}
+
+// namesOf builds a matrix's association names.
+func namesOf(srcFmt, dstFmt string, matrix, srcs, dsts uint32) router.NamesFile {
+	var nf router.NamesFile
+	for i := uint32(1); i <= srcs; i++ {
+		nf.Srcs = append(nf.Srcs, fmt.Sprintf(srcFmt, matrix, i))
+	}
+	for i := uint32(1); i <= dsts; i++ {
+		nf.Dsts = append(nf.Dsts, fmt.Sprintf(dstFmt, matrix, i))
+	}
+	return nf
+}
+
+func mustDTP(p dtp.Params) []byte {
+	b, err := dtp.Encode(p, false)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// garbled reports whether a command answers with a malformed payload.
+func (r *fakeRouter) garbled(cmd uint32) bool { return r.garble[cmd] }
+
+// get answers a read, reporting whether the command belongs to this router.
+func (r *fakeRouter) get(cmd uint32) (codec.Value, bool, bool) {
+	if r.refuse[cmd] {
+		return codec.Value{}, true, false
+	}
+	v, ok := r.values[cmd]
+	return v, ok, ok
+}
+
+// set applies a write and returns what to answer with, plus what to push.
+//
+// The answer carries the value from *before* the change, with the result code
+// appended; the new value goes out afterwards on the back channel. That is what
+// the vendor controller does, and a client that trusts the reply shows a stale
+// crosspoint because of it.
+func (r *fakeRouter) set(v codec.Value) (reply codec.Value, push *codec.Value, mine bool) {
+	if r.refuse[v.Command] {
+		return codec.Value{}, nil, false
+	}
+	if _, isRoute := r.routed[v.Command]; isRoute {
+		before := r.routed[v.Command]
+
+		items, err := dtp.Decode(v.Data)
+		if err != nil || len(items) == 0 {
+			return codec.Value{}, nil, true
+		}
+		var pin uint32
+		switch items[0].Type {
+		case dtp.TypeUintArray:
+			if len(items[0].Uints) == 0 {
+				return codec.Value{}, nil, true
+			}
+			pin = items[0].Uints[0]
+		case dtp.TypeUint:
+			pin = items[0].Uint
+		}
+		if to, ok := r.tieline[pin]; ok {
+			// The route completed through a tieline, so the tally reports the
+			// far end rather than what was asked for.
+			pin = to
+		}
+
+		r.routed[v.Command] = router.UnpackSourcePin(pin)
+		r.data(v.Command, mustDTP(dtp.Params{dtp.Uint(pin)}))
+
+		result := router.RouteOK
+		if r.results != nil {
+			if got, ok := r.results[v.Command]; ok {
+				result = got
+				// A route the controller would not make leaves the crosspoint
+				// where it was.
+				r.routed[v.Command] = before
+				r.data(v.Command, mustDTP(dtp.Params{dtp.Uint(before.Pack())}))
+			}
+		}
+
+		reply = codec.Value{
+			Command: v.Command,
+			Mode:    codec.ModeData,
+			Data:    mustDTP(dtp.Params{dtp.Uint(before.Pack()), dtp.Uint(uint32(result))}),
+		}
+		if r.badReply[v.Command] {
+			reply.Data = []byte{0xFF, 0xFF}
+		}
+		pushed := r.values[v.Command]
+		return reply, &pushed, true
+	}
+
+	if _, ok := r.values[v.Command]; !ok {
+		return codec.Value{}, nil, false
+	}
+	stored := codec.Value{Command: v.Command, Mode: v.Mode, Val: v.Val, Text: v.Text, Data: v.Data}
+	r.values[v.Command] = stored
+	return stored, nil, true
+}

--- a/internal/snell-rollcall/consumer/tally.go
+++ b/internal/snell-rollcall/consumer/tally.go
@@ -1,0 +1,160 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/router"
+)
+
+// Tally is the reason the back channel exists on a router.
+//
+// A set does not tell a client what happened: the reply carries the crosspoint
+// from before the change, and the new one arrives afterwards as a push. So a
+// panel that shows what is routed has to subscribe, and a client that sets
+// without subscribing is guessing.
+//
+// The pushes carry command numbers, not destinations, so what this file adds to
+// the value stream is the arithmetic in reverse: which matrix, level and
+// destination a command belongs to.
+
+// TallyFunc is called for each crosspoint change. It must not block: it runs on
+// the delivery loop, and the acknowledgement that asks for the next push waits
+// behind it.
+type TallyFunc func(Crosspoint)
+
+// WatchRoutes reports every crosspoint change on a router.
+//
+// It reports changes and nothing else. The specification says enabling the back
+// channel asks for what has already changed as well, but the vendor controller
+// sends nothing until something moves: subscribing to a level and waiting
+// delivers no crosspoints at all. So a caller drawing a panel reads the state
+// it wants to show with Routes and keeps it current from here, rather than
+// waiting for a picture that never arrives.
+func (p *Plugin) WatchRoutes(ctx context.Context, r *RouterInterface, fn TallyFunc) error {
+	if fn == nil {
+		return fmt.Errorf("rollcall: watching routes needs a callback")
+	}
+
+	s, err := p.session(ctx, r.Slot)
+	if err != nil {
+		return err
+	}
+
+	index := r.destIndex()
+
+	if err := s.EnableBackChannel(ctx, true); err != nil {
+		return fmt.Errorf("rollcall: open the back channel on slot %d: %w", r.Slot, err)
+	}
+
+	p.mu.RLock()
+	stop := p.events
+	p.mu.RUnlock()
+
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case push, ok := <-s.Pushes():
+				if !ok {
+					return
+				}
+				if xpt, ok := index.crosspoint(push.Frame); ok {
+					fn(xpt)
+				}
+				// The acknowledgement goes after the callback, because it is
+				// what asks for the next push: sending it first throws away
+				// the only flow control the protocol has.
+				if err := push.Ack(); err != nil {
+					p.log.Debug("rollcall: could not acknowledge a tally push",
+						"slot", r.Slot, "err", err)
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// destIndex is the reverse of the command arithmetic: which destination a
+// command number belongs to.
+type destIndex struct {
+	levels []indexedLevel
+}
+
+type indexedLevel struct {
+	matrix uint32
+	level  uint32
+	dsts   router.Table
+}
+
+// destIndex builds the reverse lookup for every level of every matrix.
+func (r *RouterInterface) destIndex() destIndex {
+	var idx destIndex
+	for _, m := range r.Matrices {
+		for _, lv := range m.Levels {
+			idx.levels = append(idx.levels, indexedLevel{
+				matrix: m.Number, level: lv.Number, dsts: lv.Dsts,
+			})
+		}
+	}
+	return idx
+}
+
+// crosspoint turns a pushed value into a crosspoint change, if it is one.
+//
+// A router pushes on the same channel as everything else, so a push that is not
+// a routed-source command is not a fault: it may be a protect, a name, or a
+// display line. Anything this cannot place is left alone.
+func (i destIndex) crosspoint(f codec.Frame) (Crosspoint, bool) {
+	if f.Type != codec.MsgRetValue && f.Type != codec.MsgSetValue {
+		return Crosspoint{}, false
+	}
+	v, err := codec.DecodeValue(f.Payload)
+	if err != nil {
+		return Crosspoint{}, false
+	}
+
+	for _, lv := range i.levels {
+		n, off, ok := lv.dsts.Index(router.Command(v.Command))
+		if !ok || off != router.OffDestRoutedSrc {
+			continue
+		}
+		xpt, err := decodeCrosspoint(v, router.SourcePin{
+			Matrix: uint8(lv.matrix), Level: uint8(lv.level), Source: uint16(n),
+		})
+		if err != nil {
+			return Crosspoint{}, false
+		}
+		return xpt, true
+	}
+	return Crosspoint{}, false
+}
+
+// Routes reads every crosspoint of one level.
+//
+// One command per destination, which is what the protocol offers: there is no
+// bulk crosspoint read, only the bulk names. On a large level that is thousands
+// of round trips, and there is no way around it — the controller will not
+// replay the current state on the back channel, so a panel reads once here and
+// keeps it current from WatchRoutes afterwards.
+func (p *Plugin) Routes(ctx context.Context, r *RouterInterface,
+	matrix, level uint32) ([]Crosspoint, error) {
+
+	lv, err := r.Level(matrix, level)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Crosspoint, 0, lv.Dsts.Count)
+	for d := uint32(1); d <= lv.Dsts.Count; d++ {
+		xpt, err := p.Route(ctx, r, matrix, level, d)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, xpt)
+	}
+	return out, nil
+}

--- a/internal/snell-rollcall/docs/oracle-centra.md
+++ b/internal/snell-rollcall/docs/oracle-centra.md
@@ -286,6 +286,50 @@ Three objects, because slot 14 is the XY Panel: a router node serves its
 routing and its names as control variables, not as menu lines, which is exactly
 what the design document says and why a menu walk finds almost nothing there.
 
+## 9. The file service is not where the names are
+
+The routing interface names a file for every bulk set — association names,
+source and destination names, mappings, multi-channel data — and this
+controller will not serve any of them:
+
+```
+open "RC_Files\AssocNames_1_8.dat"  -> errno 2, no such file or directory
+```
+
+Every node's file service is rooted at that node's **own** directory, and a
+directory listing proves it: each of them lists `.`, `..`, `soft`,
+`Template.tpl` and `TEMPLATE.ZIP`, whatever path is asked for. The path in the
+routing interface is a path in the controller's filesystem, and the two need not
+meet. Whether a shipping Sirius exposes them is unknown; this simulator does not.
+
+So a client cannot rely on the bulk path. Ours tries the file, and on failure
+reads the names one command at a time — `CMD_SRC_NAME_8` and friends, which do
+answer — recording `rollcall_names_file_unreadable` so the slowness is not a
+mystery. On a level of sixty-five thousand sources that fallback is very slow,
+which is the whole reason the file mechanism exists.
+
+Two smaller things came out of the same probe:
+
+- **Directory entries are variable-length.** `MODULE_FILEINFO_STR` declares a
+  thirteen-byte name field and the server does not send it: the header, then the
+  name and its terminator, and nothing more. An entry for `.` is twelve bytes,
+  one for `TEMPLATE.ZIP` twenty-three. Our decoder demanded the declared width
+  and could read none of them. It now reads the name as what follows the header,
+  and the captured bytes are a test.
+- **A listing ignores the path it was given.** `\`, `.`, `RC_Files` and
+  `RC_Files\` all return the same five entries.
+
+## 10. Enabling the back channel does not replay the current state
+
+`SP_BKCHNREADY` with 1 asks for changes including what has already changed. This
+controller sends nothing at all until something moves: subscribing to a level
+and waiting delivers zero crosspoints, and the first push arrives only when a
+route is made.
+
+So a panel cannot subscribe and wait for the picture to fill in. It has to read
+the crosspoints it wants to show, once, and then keep them current from the
+pushes. Our `Routes` does the reading; `WatchRoutes` does the keeping.
+
 ## 9. Reproducing it
 
 ```


### PR DESCRIPTION
Closes #1028. Stacked on #1027.

A RollCall router has no menu. Routing, names, protects and salvos are **control
variables** in a flat 32-bit command space whose numbers a client works out by
arithmetic from a root table at command 100. Walking a router's menu finds three
lines and nothing useful, which is what our consumer did until now.

Built and checked against the vendor Centra controller running as a **Sirius
800**. Measurements: `internal/snell-rollcall/docs/oracle-centra.md`.

## What it does

```go
r, _ := p.FindRouter(ctx)                       // probes command 100 on each node
n, _ := p.LevelNames(ctx, r, 1, 1, 32)          // bulk file, checksum-verified
p.WatchRoutes(ctx, r, func(x Crosspoint) {…})   // tally
p.SetRoute(ctx, r, 1, 1, 1, src, 0)             // make a route
p.Protect(ctx, r, 1, 1, 1)                      // who holds it
p.FireSalvo(ctx, r, 2)
```

Live, against the vendor controller:

```
router on slot 14 v13: 2 matrices, 4 salvos
m2/l3 names: mtx02src000001 … mtx02src000010 | mtx02dst000001 … mtx02dst000010
tally m2/l3/d2 <- m2/l3/s2
tally m2/l3/d2 <- m2/l3/s5
level 2/3 crosspoints: d1<-s1 d2<-s5 d3<-s1 d4<-s1 …
```

## Three behaviours a client gets wrong without being told

- **The reply to a set carries the previous crosspoint.** The result code says
  whether it worked; the new pin arrives afterwards as a back-channel push. A
  client that reads the reply's pin shows a stale crosspoint.
- **The tally follows tielines.** Setting source 7 can read back as matrix 2
  source 1: the pin is the *final upstream* source. Reading back what you wrote
  is not a valid expectation.
- **Enabling the back channel does not replay current state.** The
  specification says it asks for what has already changed; this controller sends
  nothing until something moves. A panel reads once with `Routes` and keeps it
  current from `WatchRoutes`.

## Names in bulk, and when they cannot be

Every name set is a file plus a checksum computed from the names rather than the
bytes, so a cached copy is trusted without fetching. But this controller names
files in **its own** filesystem, and each node's file service is rooted at that
node's directory, so `RC_Files\…` cannot be opened from anywhere. The client
falls back to one command per name — which works, and is slow — recording
`rollcall_names_file_unreadable` so the slowness is not a mystery. On a
sixty-five-thousand-source level that fallback is very slow, which is precisely
why the file mechanism exists.

## One codec fix

**Directory entries are variable-length.** `MODULE_FILEINFO_STR` declares a
thirteen-byte name field and no server sends it: the header, the name, its
terminator, nothing more — twelve bytes for `.`, twenty-three for
`TEMPLATE.ZIP`. Our decoder demanded the declared width and could read *none* of
a real listing. The captured bytes are now the test.

## Coverage

100% of statements in all six packages. The fake controller in the tests is laid
out by the same arithmetic as the real one — base 121, step 15, everything below
found from what the level above published — so a reader that gets an offset
wrong fails against it for the same reason it would fail against a Sirius.

CLI verbs follow in a separate unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)