### PR TITLE
feat(snell-rollcall): router verbs — router, route, tally

### DIFF
--- a/cmd/dhs/cli_surface_golden_test.go
+++ b/cmd/dhs/cli_surface_golden_test.go
@@ -53,7 +53,7 @@ var genericVerbs = []string{
 	"info", "walk", "tree", "get", "set", "inc", "dec", "reset", "ensure",
 	"watch", "export", "import", "extract", "diff", "convert", "discover",
 	"matrix", "usage", "replace", "invoke", "stream", "profile", "diag",
-	"validate", "health", "status", "bench",
+	"validate", "health", "status", "bench", "router", "route", "tally",
 }
 
 // emberplusOnlyVerbs / acp2OnlyVerbs are captured under their owning protocol
@@ -61,6 +61,10 @@ var genericVerbs = []string{
 var emberplusOnlyVerbs = []string{"matrix", "invoke", "stream", "profile", "bench", "usage", "replace"}
 
 var acp2OnlyVerbs = []string{"diag"}
+
+// rollcallOnlyVerbs reach a router's command space, which has no menu behind it
+// and so no generic verb that can address it.
+var rollcallOnlyVerbs = []string{"router", "route", "tally"}
 
 // perProtocolVerbs are the connectors that own a private dispatch switch
 // instead of the generic table. Killing this split is the point of the
@@ -159,6 +163,9 @@ func TestCLISurfaceGolden(t *testing.T) {
 	}
 	for _, v := range acp2OnlyVerbs {
 		add("consumer/acp2/"+v, "consumer", "acp2", v, "--help")
+	}
+	for _, v := range rollcallOnlyVerbs {
+		add("consumer/rollcall/"+v, "consumer", "rollcall", v, "--help")
 	}
 
 	// 3. Every connector that owns a private dispatch switch.

--- a/cmd/dhs/cmd_rollcall_router.go
+++ b/cmd/dhs/cmd_rollcall_router.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"dhs/internal/snell-rollcall/codec/router"
+	rollcall "dhs/internal/snell-rollcall/consumer"
+)
+
+// A RollCall router is not a device with a menu. Its routing, its names and its
+// protects are control variables in a flat command space, so none of the
+// generic verbs reach them: walking a router finds three menu lines and nothing
+// to route with. These three verbs are that command space from the command
+// line.
+
+func helpRollcallRouter() {
+	fmt.Println(`dhs consumer rollcall router <host> [--slot N] [--output text|json]
+
+Find the routing interface and print what it publishes: the matrices, their
+levels, and how many sources and destinations each level has.
+
+The interface lives on one node of a controller and nothing in a device list
+says which — on a Centra the matrices are their own nodes and neither serves
+it — so without --slot every node is probed. A node that is not a router
+refuses, which is how they are told apart.
+
+Examples:
+  dhs consumer rollcall router 10.6.250.105
+  dhs consumer rollcall router 10.6.250.105 --slot 14 --output json`)
+}
+
+func helpRollcallRoute() {
+	fmt.Println(`dhs consumer rollcall route <host> --matrix M --level L --dest D [--source S]
+                                   [--slot N] [--protect-id ID] [--output text|json]
+
+Read a crosspoint, or make one when --source is given.
+
+Two things about this protocol are worth knowing before reading the output:
+
+  * The reply to a route carries the crosspoint from BEFORE the change. What
+    was actually routed arrives afterwards on the back channel, so this verb
+    reads the destination again and prints that.
+
+  * The tally follows tielines. Routing source 7 can read back as matrix 2
+    source 1, because the number reported is the final upstream source rather
+    than the one asked for. That is the router working.
+
+Examples:
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --source 9
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --output json`)
+}
+
+func helpRollcallTally() {
+	fmt.Println(`dhs consumer rollcall tally <host> [--matrix M --level L] [--slot N] [--names]
+
+Print the crosspoints of a level and then follow them live; Ctrl+C to stop.
+
+The reading comes first because it has to: enabling the back channel does not
+replay the current state on a real controller, so a panel that only subscribes
+sees nothing until something moves.
+
+With --matrix and --level it reads that level first. Without them it subscribes
+to everything and prints only what changes.
+
+Examples:
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1 --names`)
+}
+
+// rollcallPlugin connects and returns the plugin as a RollCall one.
+func rollcallPlugin(ctx context.Context, host string, cf *commonFlags) (*rollcall.Plugin, func(), error) {
+	plug, cleanup, err := connect(ctx, host, cf)
+	if err != nil {
+		return nil, nil, err
+	}
+	rc, ok := plug.(*rollcall.Plugin)
+	if !ok {
+		cleanup()
+		return nil, nil, fmt.Errorf("this verb is only supported for the rollcall protocol")
+	}
+	return rc, cleanup, nil
+}
+
+// findRouter locates the routing interface, on a named slot or by probing.
+func findRouter(ctx context.Context, p *rollcall.Plugin, slot int) (*rollcall.RouterInterface, error) {
+	if slot >= 0 {
+		return p.RouterAt(ctx, slot)
+	}
+	return p.FindRouter(ctx)
+}
+
+func runRollcallRouter(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("router", flag.ExitOnError)
+	fs.Usage = verbUsageFn(fs, helpRollcallRouter)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", -1, "node to read; without it every node is probed")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002)")
+
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer rollcall router <host> [--slot N]")
+	}
+	_ = parseVerbFlags(fs, rest)
+
+	p, cleanup, err := rollcallPlugin(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	r, err := findRouter(ctx, p, *slot)
+	if err != nil {
+		return err
+	}
+
+	if strings.EqualFold(*output, "json") {
+		return json.NewEncoder(os.Stdout).Encode(routerJSON(r))
+	}
+
+	fmt.Printf("router       %s\n", nameOrUnset(r.Name))
+	fmt.Printf("slot         %d (%s)\n", r.Slot, r.Addr)
+	fmt.Printf("interface    version %d\n", r.Version)
+	fmt.Printf("salvos       %d\n", r.Salvos)
+	fmt.Printf("devices      %d\n", r.Devices)
+	fmt.Println()
+
+	// The writer buffers, so a write cannot fail here; Flush is where an error
+	// would surface, and that one is returned.
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "MATRIX\tLEVEL\tNAME\tSOURCES\tDESTINATIONS")
+	for _, m := range r.Matrices {
+		for _, lv := range m.Levels {
+			_, _ = fmt.Fprintf(w, "%d %s\t%d\t%s\t%d\t%d\n",
+				m.Number, m.Name, lv.Number, lv.Name, lv.Srcs.Count, lv.Dsts.Count)
+		}
+	}
+	return w.Flush()
+}
+
+func runRollcallRoute(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("route", flag.ExitOnError)
+	fs.Usage = verbUsageFn(fs, helpRollcallRoute)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", -1, "node to use; without it every node is probed")
+	matrix := fs.Int("matrix", 1, "matrix number, counting from one")
+	level := fs.Int("level", 1, "level number, counting from one")
+	dest := fs.Int("dest", 0, "destination number, counting from one")
+	source := fs.Int("source", 0, "source to route; omit to read what is routed")
+	srcMatrix := fs.Int("source-matrix", 0, "matrix the source is on (default: the destination's)")
+	srcLevel := fs.Int("source-level", 0, "level the source is on (default: the destination's)")
+	protectID := fs.Int("protect-id", 0, "panel id for a temporary protected override")
+	output := fs.String("output", "text", "output format: text | json (ADR-0002)")
+
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer rollcall route <host> --matrix M --level L --dest D [--source S]")
+	}
+	_ = parseVerbFlags(fs, rest)
+
+	if *dest < 1 {
+		return fmt.Errorf("--dest is required and counts from one")
+	}
+
+	p, cleanup, err := rollcallPlugin(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	r, err := findRouter(ctx, p, *slot)
+	if err != nil {
+		return err
+	}
+
+	m, l, d := uint32(*matrix), uint32(*level), uint32(*dest)
+
+	var xpt rollcall.Crosspoint
+	if *source > 0 {
+		pin := router.SourcePin{
+			Matrix: uint8(orDefault(*srcMatrix, *matrix)),
+			Level:  uint8(orDefault(*srcLevel, *level)),
+			Source: uint16(*source),
+		}
+		if xpt, err = takeRoute(ctx, p, r, m, l, d, pin, uint16(*protectID)); err != nil {
+			return err
+		}
+	} else if xpt, err = p.Route(ctx, r, m, l, d); err != nil {
+		return err
+	}
+
+	if strings.EqualFold(*output, "json") {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"matrix":      m,
+			"level":       l,
+			"destination": d,
+			"source": map[string]any{
+				"matrix": xpt.Source.Matrix,
+				"level":  xpt.Source.Level,
+				"source": xpt.Source.Source,
+			},
+			"routed": xpt.Source.Source != 0,
+		})
+	}
+
+	if xpt.Source.Source == 0 {
+		fmt.Printf("matrix %d level %d destination %d has nothing routed to it\n", m, l, d)
+		return nil
+	}
+	fmt.Printf("matrix %d level %d destination %d <- %s\n", m, l, d, xpt.Source)
+	return nil
+}
+
+func runRollcallTally(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("tally", flag.ExitOnError)
+	fs.Usage = verbUsageFn(fs, helpRollcallTally)
+	cf := addCommonFlags(fs)
+	slot := fs.Int("slot", -1, "node to use; without it every node is probed")
+	matrix := fs.Int("matrix", 0, "matrix to read first, counting from one")
+	level := fs.Int("level", 0, "level to read first, counting from one")
+	withNames := fs.Bool("names", false, "fetch the level's names and show them beside the numbers")
+
+	host, rest, err := popHost(args)
+	if err != nil {
+		return fmt.Errorf("usage: dhs consumer rollcall tally <host> [--matrix M --level L]")
+	}
+	_ = parseVerbFlags(fs, rest)
+
+	p, cleanup, err := rollcallPlugin(ctx, host, cf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	r, err := findRouter(ctx, p, *slot)
+	if err != nil {
+		return err
+	}
+
+	var names rollcall.Names
+	if *withNames && *matrix > 0 && *level > 0 {
+		names, err = p.LevelNames(ctx, r, uint32(*matrix), uint32(*level), router.NameWidth32)
+		if err != nil {
+			// Names are a convenience. A tally without them is still a tally.
+			fmt.Fprintf(os.Stderr, "warning: names unavailable: %v\n", err)
+		}
+	}
+
+	show := func(x rollcall.Crosspoint) {
+		line := fmt.Sprintf("m%d/l%d/d%-4d <- ", x.Dest.Matrix, x.Dest.Level, x.Dest.Source)
+		if x.Source.Source == 0 {
+			line += "(nothing)"
+		} else {
+			line += x.Source.String()
+		}
+		if len(names.Srcs) > 0 || len(names.Dsts) > 0 {
+			line += fmt.Sprintf("   %s <- %s",
+				nameOrBlank(names.Dst(uint32(x.Dest.Source))),
+				nameOrBlank(names.Src(uint32(x.Source.Source))))
+		}
+		fmt.Println(line)
+	}
+
+	// The current state first: enabling the back channel does not replay it, so
+	// a client that only subscribes sees nothing until something moves.
+	if *matrix > 0 && *level > 0 {
+		xpts, err := p.Routes(ctx, r, uint32(*matrix), uint32(*level))
+		if err != nil {
+			return err
+		}
+		for _, x := range xpts {
+			show(x)
+		}
+		fmt.Println("--- following changes; Ctrl+C to stop")
+	}
+
+	if err := p.WatchRoutes(ctx, r, show); err != nil {
+		return err
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-stop:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// takeRoute makes a route and returns what the router ended up with.
+//
+// Neither the reply nor an immediate read says that: the reply carries the
+// crosspoint from before the change, and the controller applies asynchronously,
+// so a read straight afterwards usually still shows the old source. What says
+// it is the back-channel push, which is the mechanism a panel uses and the only
+// one that tells the truth about tielines.
+func takeRoute(ctx context.Context, p *rollcall.Plugin, r *rollcall.RouterInterface,
+	m, l, d uint32, src router.SourcePin, protectID uint16) (rollcall.Crosspoint, error) {
+
+	tally := make(chan rollcall.Crosspoint, 8)
+	if err := p.WatchRoutes(ctx, r, func(x rollcall.Crosspoint) {
+		if uint32(x.Dest.Matrix) == m && uint32(x.Dest.Level) == l && uint32(x.Dest.Source) == d {
+			select {
+			case tally <- x:
+			default:
+			}
+		}
+	}); err != nil {
+		return rollcall.Crosspoint{}, err
+	}
+
+	if _, err := p.SetRoute(ctx, r, m, l, d, src, protectID); err != nil {
+		return rollcall.Crosspoint{}, err
+	}
+
+	select {
+	case x := <-tally:
+		return x, nil
+	case <-time.After(routeTallyWait):
+		// The route may still have been made: a controller that reports no
+		// tally is unusual rather than impossible, and the read is the best
+		// answer left.
+		return p.Route(ctx, r, m, l, d)
+	case <-ctx.Done():
+		return rollcall.Crosspoint{}, ctx.Err()
+	}
+}
+
+// routeTallyWait is how long to wait for a controller to report a route it has
+// accepted. It is a bound on a reply that has already been acknowledged, not a
+// protocol timeout: something has gone wrong if it expires.
+const routeTallyWait = 3 * time.Second
+
+// routerJSON is the machine shape of a routing interface.
+func routerJSON(r *rollcall.RouterInterface) map[string]any {
+	matrices := make([]map[string]any, 0, len(r.Matrices))
+	for _, m := range r.Matrices {
+		levels := make([]map[string]any, 0, len(m.Levels))
+		for _, lv := range m.Levels {
+			levels = append(levels, map[string]any{
+				"level":        lv.Number,
+				"name":         lv.Name,
+				"sources":      lv.Srcs.Count,
+				"destinations": lv.Dsts.Count,
+			})
+		}
+		matrices = append(matrices, map[string]any{
+			"matrix":                   m.Number,
+			"name":                     m.Name,
+			"controller":               m.Controller,
+			"source_associations":      m.SrcAssocs.Count,
+			"destination_associations": m.DstAssocs.Count,
+			"levels":                   levels,
+		})
+	}
+	return map[string]any{
+		"slot":              r.Slot,
+		"address":           r.Addr.String(),
+		"name":              r.Name,
+		"interface_version": r.Version,
+		"salvos":            r.Salvos,
+		"devices":           r.Devices,
+		"matrices":          matrices,
+	}
+}
+
+func nameOrUnset(s string) string {
+	if s == "" {
+		return "(unset)"
+	}
+	return s
+}
+
+func nameOrBlank(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// orDefault takes the first value when it was given, and the second otherwise.
+func orDefault(given, fallback int) int {
+	if given > 0 {
+		return given
+	}
+	return fallback
+}

--- a/cmd/dhs/cmd_rollcall_router_test.go
+++ b/cmd/dhs/cmd_rollcall_router_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"dhs/internal/snell-rollcall/codec"
+	"dhs/internal/snell-rollcall/codec/router"
+	rollcall "dhs/internal/snell-rollcall/consumer"
+)
+
+func TestRollcallRouteRequiresADestination(t *testing.T) {
+	// A crosspoint is named by its destination, and there is no sensible
+	// default: destination zero does not exist, since the command space counts
+	// from one.
+	err := runRollcallRoute(context.Background(), []string{"127.0.0.1:2050"})
+	if err == nil {
+		t.Fatal("route without --dest should fail")
+	}
+	if !strings.Contains(err.Error(), "--dest") {
+		t.Errorf("error = %v, want it to name the missing flag", err)
+	}
+}
+
+func TestRollcallVerbsNeedAHost(t *testing.T) {
+	ctx := context.Background()
+	for name, run := range map[string]func(context.Context, []string) error{
+		"router": runRollcallRouter,
+		"route":  runRollcallRoute,
+		"tally":  runRollcallTally,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := run(ctx, nil)
+			if err == nil {
+				t.Fatal("a verb with no host should fail")
+			}
+			if !strings.Contains(err.Error(), "usage:") {
+				t.Errorf("error = %v, want usage", err)
+			}
+		})
+	}
+}
+
+func TestRouterJSONShape(t *testing.T) {
+	r := &rollcall.RouterInterface{
+		Slot:    14,
+		Addr:    codec.Address{Unit: 0x81, Index: codec.IndexUnknown},
+		Version: 13,
+		Name:    "Sirius",
+		Salvos:  4,
+		Devices: 100,
+		Matrices: []rollcall.RouterMatrix{{
+			Number:     1,
+			Name:       "Matrix 1",
+			Controller: 1,
+			SrcAssocs:  router.Table{Count: 10},
+			DstAssocs:  router.Table{Count: 12},
+			Levels: []rollcall.RouterLevel{{
+				Number: 1,
+				Name:   "Level 1",
+				Srcs:   router.Table{Count: 1024},
+				Dsts:   router.Table{Count: 512},
+			}},
+		}},
+	}
+
+	body, err := json.Marshal(routerJSON(r))
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got["interface_version"] != float64(13) || got["name"] != "Sirius" {
+		t.Errorf("router = %v", got)
+	}
+	matrices, ok := got["matrices"].([]any)
+	if !ok || len(matrices) != 1 {
+		t.Fatalf("matrices = %v", got["matrices"])
+	}
+	m := matrices[0].(map[string]any)
+	if m["destination_associations"] != float64(12) {
+		t.Errorf("destination associations = %v", m["destination_associations"])
+	}
+	levels := m["levels"].([]any)
+	lv := levels[0].(map[string]any)
+	if lv["sources"] != float64(1024) || lv["destinations"] != float64(512) {
+		t.Errorf("level = %v", lv)
+	}
+}
+
+func TestRouteSourceDefaultsToTheDestinationsPlane(t *testing.T) {
+	// A source without its own matrix and level is on the destination's, which
+	// is the ordinary case: routing within one plane.
+	if got := orDefault(0, 3); got != 3 {
+		t.Errorf("orDefault(0, 3) = %d, want the fallback", got)
+	}
+	if got := orDefault(2, 3); got != 2 {
+		t.Errorf("orDefault(2, 3) = %d, want what was given", got)
+	}
+}
+
+func TestNamePlaceholders(t *testing.T) {
+	if got := nameOrUnset(""); got != "(unset)" {
+		t.Errorf("an unnamed router printed as %q", got)
+	}
+	if got := nameOrUnset("R1"); got != "R1" {
+		t.Errorf("a named router printed as %q", got)
+	}
+	if got := nameOrBlank(""); got != "-" {
+		t.Errorf("a missing name printed as %q", got)
+	}
+	if got := nameOrBlank("CAM 1"); got != "CAM 1" {
+		t.Errorf("a name printed as %q", got)
+	}
+}

--- a/cmd/dhs/main.go
+++ b/cmd/dhs/main.go
@@ -187,6 +187,9 @@ var commands = []command{
 	{"health", "print 3-layer session health (reachable / connected / live)", helpHealth, runHealth},
 	{"status", "one-shot device status: session health + identity (--output json)", helpStatus, runStatus},
 	{"bench", "Ember+ — fire N matrix crosspoint ops over one TCP session and time it", helpBench, runEmberplusBench},
+	{"router", "read a router's routing interface: matrices, levels, sizes (RollCall only)", helpRollcallRouter, runRollcallRouter},
+	{"route", "read or make one crosspoint (RollCall only)", helpRollcallRoute, runRollcallRoute},
+	{"tally", "print a level's crosspoints and follow them live (RollCall only)", helpRollcallTally, runRollcallTally},
 }
 
 func helpBench() {

--- a/cmd/dhs/testdata/golden/cli-surface.txt
+++ b/cmd/dhs/testdata/golden/cli-surface.txt
@@ -878,6 +878,61 @@ Example — 1000 connects on the integration demo's nToN matrix:
     --path dhs-emberplus-integration.nToN.matrix \
     --n 1000 --op connect
 
+========== consumer/acp1/router ==========
+$ dhs consumer acp1 router --help
+dhs consumer rollcall router <host> [--slot N] [--output text|json]
+
+Find the routing interface and print what it publishes: the matrices, their
+levels, and how many sources and destinations each level has.
+
+The interface lives on one node of a controller and nothing in a device list
+says which — on a Centra the matrices are their own nodes and neither serves
+it — so without --slot every node is probed. A node that is not a router
+refuses, which is how they are told apart.
+
+Examples:
+  dhs consumer rollcall router 10.6.250.105
+  dhs consumer rollcall router 10.6.250.105 --slot 14 --output json
+
+========== consumer/acp1/route ==========
+$ dhs consumer acp1 route --help
+dhs consumer rollcall route <host> --matrix M --level L --dest D [--source S]
+                                   [--slot N] [--protect-id ID] [--output text|json]
+
+Read a crosspoint, or make one when --source is given.
+
+Two things about this protocol are worth knowing before reading the output:
+
+  * The reply to a route carries the crosspoint from BEFORE the change. What
+    was actually routed arrives afterwards on the back channel, so this verb
+    reads the destination again and prints that.
+
+  * The tally follows tielines. Routing source 7 can read back as matrix 2
+    source 1, because the number reported is the final upstream source rather
+    than the one asked for. That is the router working.
+
+Examples:
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --source 9
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --output json
+
+========== consumer/acp1/tally ==========
+$ dhs consumer acp1 tally --help
+dhs consumer rollcall tally <host> [--matrix M --level L] [--slot N] [--names]
+
+Print the crosspoints of a level and then follow them live; Ctrl+C to stop.
+
+The reading comes first because it has to: enabling the back channel does not
+replay the current state on a real controller, so a panel that only subscribes
+sees nothing until something moves.
+
+With --matrix and --level it reads that level first. Without them it subscribes
+to everything and prints only what changes.
+
+Examples:
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1 --names
+
 ========== consumer/emberplus/matrix ==========
 $ dhs consumer emberplus matrix --help
 acp matrix — set matrix crosspoint connections (Ember+ only)
@@ -1063,6 +1118,61 @@ DESCRIPTION
 EXAMPLES
   acp diag 10.41.40.195 --slot 0
   acp diag 10.41.40.195 --slot 1
+
+========== consumer/rollcall/router ==========
+$ dhs consumer rollcall router --help
+dhs consumer rollcall router <host> [--slot N] [--output text|json]
+
+Find the routing interface and print what it publishes: the matrices, their
+levels, and how many sources and destinations each level has.
+
+The interface lives on one node of a controller and nothing in a device list
+says which — on a Centra the matrices are their own nodes and neither serves
+it — so without --slot every node is probed. A node that is not a router
+refuses, which is how they are told apart.
+
+Examples:
+  dhs consumer rollcall router 10.6.250.105
+  dhs consumer rollcall router 10.6.250.105 --slot 14 --output json
+
+========== consumer/rollcall/route ==========
+$ dhs consumer rollcall route --help
+dhs consumer rollcall route <host> --matrix M --level L --dest D [--source S]
+                                   [--slot N] [--protect-id ID] [--output text|json]
+
+Read a crosspoint, or make one when --source is given.
+
+Two things about this protocol are worth knowing before reading the output:
+
+  * The reply to a route carries the crosspoint from BEFORE the change. What
+    was actually routed arrives afterwards on the back channel, so this verb
+    reads the destination again and prints that.
+
+  * The tally follows tielines. Routing source 7 can read back as matrix 2
+    source 1, because the number reported is the final upstream source rather
+    than the one asked for. That is the router working.
+
+Examples:
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --source 9
+  dhs consumer rollcall route 10.6.250.105 --matrix 1 --level 1 --dest 4 --output json
+
+========== consumer/rollcall/tally ==========
+$ dhs consumer rollcall tally --help
+dhs consumer rollcall tally <host> [--matrix M --level L] [--slot N] [--names]
+
+Print the crosspoints of a level and then follow them live; Ctrl+C to stop.
+
+The reading comes first because it has to: enabling the back channel does not
+replay the current state on a real controller, so a panel that only subscribes
+sees nothing until something moves.
+
+With --matrix and --level it reads that level first. Without them it subscribes
+to everything and prints only what changes.
+
+Examples:
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1
+  dhs consumer rollcall tally 10.6.250.105 --matrix 1 --level 1 --names
 
 ========== consumer/ccm/<dispatcher-help> ==========
 $ dhs consumer ccm --help


### PR DESCRIPTION
Stacked on #1029, which built the router client with no way to reach it from a
command line.

```
dhs consumer rollcall router <host>                       what it publishes
dhs consumer rollcall route  <host> --matrix 1 --level 1 --dest 4 [--source 9]
dhs consumer rollcall tally  <host> --matrix 1 --level 1 [--names]
```

Live, against the vendor Centra as a Sirius 800:

```
$ dhs consumer rollcall router 127.0.0.1:2057
router       <not set>
slot         14 (0000-81-00)
interface    version 13
salvos       4
devices      100

MATRIX         LEVEL  NAME          SOURCES  DESTINATIONS
1 R1 Matrix 1  1      R1M1 Level 1  10       10
1 R1 Matrix 1  2      R1M1 Level 2  10       10
2 R1 Matrix 2  1      R1M2 Level 1  10       10
2 R1 Matrix 2  2      R1M2 Level 2  10       10
2 R1 Matrix 2  3      R1M2 Level 3  10       10

$ dhs consumer rollcall tally 127.0.0.1:2057 --matrix 2 --level 1 --names
m2/l1/d1    <- m2/l1/s1   mtx02dst000001 <- mtx02src000001
…
--- following changes; Ctrl+C to stop
```

## Each verb is shaped by something measured, not by the API

- **`route` waits for the tally.** Neither the reply nor an immediate read says
  what happened: the reply carries the crosspoint from *before* the set, and the
  controller applies asynchronously. Using the verb against the Centra is how
  that surfaced — it printed the previous source until it subscribed first.
- **`tally` reads the level before following it**, because enabling the back
  channel does not replay current state on a real controller. Subscribe-only
  shows nothing until something moves.
- **`router` probes when no `--slot` is given**, because nothing in a device
  list says which node serves the interface.

A route made from one process shows up in another's tally, which is the check
that matters for a panel.

The CLI surface golden gains the three verbs; `cmd/dhs` has no coverage floor,
and the new pure helpers plus argument validation are tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)