### PR TITLE
docs(snell-rollcall): the operator's set — README, runbook, consumer, oracle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,7 +93,7 @@ concerns here.
 
 | Folder | State |
 |---|---|
-| `internal/snell-rollcall/` | **in progress** (epic #1009, gate lifted by the owner 2026-09-07). The ADR-0025 step-1 audit is done and the wire is validated against a live oracle on `10.6.250.105` — consumer read/write/subscribe proven against the real stack, and a throwaway producer spike rendered and driven by RollCall Control Panel 4.12.48. Landed so far: `CLAUDE.md` (wire context) + `docs/` (audit, DM/UI analysis, 1 623 captured frames, 560 menu lines). Still to come, one PR each: `codec/` · `session/` · `consumer/` · `provider/` · `wireshark/` · `integration/` · `testdata/`. No Go code and no registry entry yet. |
+| `internal/snell-rollcall/` | **shipping the connector** (epic #1009). Consumer, provider, session layer and codec are all at 100% statement coverage with CI floors, registered in both registries, and driven from the CLI. Both wire generations are served from one model. Router control implements the Full Control command set — discovery, matrices, levels, names in bulk, crosspoints, protects, salvos, tally — and every offset in it is measured against the vendor Centra controller running as a Sirius 800 (`docs/oracle-centra.md`). Ships `wireshark/dhs_snell_rollcall.lua` with a replay test over 90 KB of captured live traffic, and an Ansible integration play with an emulator tier, a read-only live-device tier and a loopback tier. Outstanding: a DM/manifest generator and the per-product fixture set. |
 | `internal/cerebrum-nb/provider/` | **consumer-only by design at this stage** — only the consumer + codec + wireshark layers are shipped; no `provider/` folder exists yet on disk. Intentionally not in scope at the current stage per `internal/cerebrum-nb/CLAUDE.md`. |
 
 ---

--- a/internal/snell-rollcall/docs/README.md
+++ b/internal/snell-rollcall/docs/README.md
@@ -1,0 +1,85 @@
+# Snell RollCall
+
+RollCall is Snell's device control protocol: units on a network, each with
+ports, each port carrying a menu of objects a client reads and writes. It is
+what an IQ frame, a Centra controller and a Sirius router all speak.
+
+| Role | Doc | State |
+|---|---|---|
+| Operator runbook | [runbook.md](runbook.md) | bring-up, verbs, what to check when it does not work |
+| Consumer | [consumer.md](consumer.md) | the outbound connector |
+| Provider | [provider.md](provider.md) | serving a canonical tree as a gateway |
+| What the wire looks like | [../CLAUDE.md](../CLAUDE.md) | wire format, quirks, what not to do |
+| Specification coverage | [spec-coverage.md](spec-coverage.md) | every message type and structure, checked by a test |
+| Measured behaviour | [oracle-centra.md](oracle-centra.md) | what a vendor controller actually does |
+| Device model and UI | [dm-and-ui.md](dm-and-ui.md) | how the tree maps to the neutral model |
+
+## The two things that make RollCall unusual
+
+**There are two wire generations and one connection carries both.** The
+original is 16-bit: command numbers and menu indices fit sixteen bits, and
+strings live in twenty-byte fixed fields. The 2014 extension widens both. Which
+one a session speaks is decided by the `SV_LONGSTR` bit in its `SP_CALL`, not by
+the device, so a client with two sessions to one unit can be speaking both at
+once. Services are granted all-or-nothing: a call naming one service the peer
+does not have is refused entirely.
+
+**A router has no menu.** Every other device describes itself through the menu
+service. A router controller serves its routing, its names, its protects and
+its salvos as control variables in a flat 32-bit command space, whose numbers a
+client works out by arithmetic from a root table at command 100. Walking a
+router's menu finds three lines and nothing useful. See
+[oracle-centra.md](oracle-centra.md) §2.
+
+## Layout
+
+```
+internal/snell-rollcall/
+  codec/          the wire format, stdlib-only (ADR-0006)
+    dtp/          Data Transfer Params, which the routing interface rides on
+    router/       the Full Control command arithmetic and its file formats
+  session/        links, sessions, channels, the back channel, keepalive
+  consumer/       the outbound connector, both generations, router control
+  provider/       serving a canonical tree as a RollCall gateway
+  wireshark/      dhs_snell_rollcall.lua — the byte-exact reference
+  integration/    replay tests against captured traffic (-tags integration)
+  testdata/       trees and fixtures
+  assets/         the specification, the vendor sources, the emulators
+```
+
+## Specification and vendor material
+
+| What | Where |
+|---|---|
+| RollCall Technical Specification Rev 14 | [`assets/Protocol/Docs`](../assets/Protocol/Docs) |
+| Full Control Command Set (routers) | [`assets/Protocol/Docs/Full Control Command Set.docx`](../assets/Protocol/Docs) |
+| Full RollCall Control of Routers (the design behind it) | same directory |
+| Vendor C sources (`FileServer.c`, `MsgHandlers.c`, …) | [`assets/Protocol/Source`](../assets/Protocol/Source) |
+| Vendor headers (`rc3comm.h`, `RC3FILE.H`, `RC3TYPES.H`) | same tree |
+| Centra controller emulator, runs as a Sirius 800 | [`assets/Emulator/RouterSimulator`](../assets/Emulator/RouterSimulator) |
+| Wireshark dissector | [`wireshark/dhs_snell_rollcall.lua`](../wireshark/dhs_snell_rollcall.lua) |
+
+When the specification, a device and our codec disagree, the dissector breaks
+the tie first: it is what you open before you open the Go code.
+
+## Quick start
+
+```
+# What is on the other end
+dhs consumer rollcall info 10.6.250.105
+
+# What one node offers
+dhs consumer rollcall walk 10.6.250.105 --slot 1
+
+# Read and write an object
+dhs consumer rollcall get 10.6.250.105 --slot 1 --label gain
+dhs consumer rollcall set 10.6.250.105 --slot 1 --label gain --value -6
+
+# A router
+dhs consumer rollcall router 10.6.250.105
+dhs consumer rollcall route  10.6.250.105 --matrix 1 --level 1 --dest 4 --source 9
+dhs consumer rollcall tally  10.6.250.105 --matrix 1 --level 1 --names
+
+# Serve a tree as a gateway
+dhs producer rollcall serve --tree tree.json --port 2050
+```

--- a/internal/snell-rollcall/docs/consumer.md
+++ b/internal/snell-rollcall/docs/consumer.md
@@ -1,0 +1,144 @@
+# RollCall consumer
+
+The outbound connector: `dhs consumer rollcall <verb> <host>`. It implements
+the neutral `consumer.Protocol` on top of the session layer, and adds the
+router command space, which nothing neutral has a shape for.
+
+---
+
+## Connecting
+
+One TCP connection to an IPShare gateway carries everything. The first message
+on it is a device enquiry addressed to the broadcast address, because a client
+knows neither its own address nor the gateway's until the gateway answers:
+
+```
+→ GETDEVINFO  0000-00-00:FF → 0000-00-00:FF
+← RETDEVINFO  0000-08-00:FF → 0000-01-E0:FF
+```
+
+The reply's **destination** is the address being assigned to us. The reply's
+**source** is the gateway. Both come from the frame header rather than from the
+payload, because the address inside a `DEVICEINFO_STR` is never rewritten as a
+message crosses a bridge and so means nothing about the route.
+
+## Sessions
+
+A session is a set of services at a user level, and the services are granted
+all-or-nothing: a call naming one the peer does not have is refused entirely.
+So the mask asked for is the intersection of what we want with what the peer
+advertised — measured against a controller that has no display service and
+refuses every call naming one.
+
+Sessions are per node and kept, because opening one costs a round trip and
+closing one is what a unit runs out of. There are three kinds:
+
+| Session | Services | Why separate |
+|---|---|---|
+| control | menus, control, display where offered, long strings where offered | the one everything ordinary uses |
+| file | file | a unit without a file service must still be controllable |
+| map | map | a request outside a session's services is answered `INVSESS` |
+
+Two indices matter and confusing them is the defect the session layer exists to
+prevent. Ours goes in the source of everything we send; the peer's goes in the
+destination. A push arrives addressed to ours.
+
+## Slots
+
+A slot is a position in the device's own enumeration, and its address is
+whatever the device put there — a port on a frame, a unit on a controller. The
+address appears in the slot's identity, because on a controller a slot number
+is a position in a list rather than a place in a frame.
+
+A slot past the end of the enumeration is still addressed rather than refused:
+a gateway ages a map entry out after sixty seconds of silence, so a node
+missing from the list is one that has gone quiet.
+
+## Walking a menu
+
+A menu is a flat array with nested spans: a container's step is the size of its
+whole subtree, not the count of its children. The walk turns that into a tree,
+and the tree is what makes `--label` and `--path` work without the caller
+knowing a command number.
+
+Both generations produce the same tree. A 16-bit client fetches a block header
+and then each line by offset; a long-string client asks for a count and then
+each line by absolute index. What arrives differs in width, not in meaning.
+
+Menus are cached per slot. A `FUNCLISTCHG` or `FUNCSTYLECHG` push drops the
+cache, because a line that became hidden or disabled is a line whose access we
+would otherwise report wrongly.
+
+## Values
+
+A read answers with the value; a write answers with the value that was
+**stored**. That is worth relying on: a device clamps silently, and only the
+reply says what it clamped to.
+
+| Kind | Wire form | Note |
+|---|---|---|
+| number | `ModeValue`, scaled by the line's divisor | a real is an integer over a factor; the format string is where the unit lives |
+| boolean | `ModeValue`, 0 or 1 | on a checkbox the *minimum* field is the "on" value, not a bound |
+| string | `ModeString` | 19 usable bytes in the older generation, 63 in the newer |
+| raw | `ModeData` | reported, never written |
+
+Both `ModeValue` and `ModeString` set at once is normal rather than
+exceptional: a device answers a checksum with the number -1686180113 *and* the
+string "0x9B7EEEEF", and a display wants the string.
+
+## Subscriptions
+
+Two messages open a value stream and the second is easy to miss: opening the
+back channel makes a session able to receive pushes, and asking for change
+reporting is what makes a device send value pushes at all. With only the first,
+a subscription looks live and nothing arrives.
+
+Every push is a request. The acknowledgement is what asks for the next, so it
+goes after the callback has run: sending it first throws away the only flow
+control the protocol has.
+
+## Files
+
+The file service is not an extra. A router publishes its names through it, and
+the vendor's Control Panel will not render a device without reading
+`TEMPLATE.ZIP` from it.
+
+Two fields change meaning between a request and its own reply, and getting it
+wrong reads a file as a stream of empty blocks rather than failing:
+
+| Message | `rOffset` | `rExtra` |
+|---|---|---|
+| `SP_FILEOPEN` | unused | the open flags |
+| `SP_RETFILEOPEN` | the peer's block size | the error |
+| `SP_FILEREAD` | where to read from | how many bytes |
+| `SP_RETFILEREAD` | how many were read | the error |
+
+Always open binary. Text mode makes a peer translate line endings, which
+corrupts an archive or a names file silently: the read succeeds and the bytes
+are wrong.
+
+## Routers
+
+A router has no menu. See [runbook.md](runbook.md) §6 for the operational view;
+the shape of the client is:
+
+```go
+r, _ := p.FindRouter(ctx)                     // probes command 100 on each node
+names, _ := p.LevelNames(ctx, r, 1, 1, 32)    // bulk file, checksum-verified
+p.WatchRoutes(ctx, r, func(x Crosspoint) {…}) // tally
+p.SetRoute(ctx, r, 1, 1, 4, src, 0)           // make a route
+p.Protect(ctx, r, 1, 1, 4)                    // who holds it
+p.FireSalvo(ctx, r, 2)
+```
+
+`FindRouter` probes because nothing in a device list says which node serves the
+interface. The test is strict: the interface version must be a number in a
+plausible range, because a card is not obliged to refuse command 100 — on a
+Centra the input cards answer it with their own model number as a string.
+
+## Compliance
+
+Every deviation is absorbed and counted rather than worked around. The list is
+in [runbook.md](runbook.md) §7. `ComplianceEvents()` returns them, one entry per
+kind with a count and the most recent detail: a device that misbehaves on every
+one of sixty-five thousand destinations must not fill memory with the evidence.

--- a/internal/snell-rollcall/docs/oracle-centra.md
+++ b/internal/snell-rollcall/docs/oracle-centra.md
@@ -4,7 +4,9 @@ What a real Snell router controller does on the wire, measured rather than
 read. Every claim below was produced by driving
 `assets/Emulator/RouterSimulator/Router2.zip` — the vendor's own
 `CentraController.exe`, run as a Sirius 800
-(`CENTRA_SIMULATED_ROUTER=3`) — with our own session layer.
+(`CENTRA_SIMULATED_ROUTER=3`) — with our own session layer. It answers as a
+`Nucleus 2`; §11 says why the id and the controller type are not the same
+question.
 
 This matters because the Full Control Command Set document lists the
 per-matrix, per-level and per-entity commands "in a similar fashion" without
@@ -330,13 +332,97 @@ So a panel cannot subscribe and wait for the picture to fill in. It has to read
 the crosspoints it wants to show, once, and then keep them current from the
 pushes. Our `Routes` does the reading; `WatchRoutes` does the keeping.
 
-## 9. Reproducing it
+## 11. What the router id actually selects
+
+`CENTRA_SIMULATED_ROUTER` picks the **chassis model**, and that decides whether
+the card simulation applies at all. Five clean copies of the same build, one
+per id, each on its own ports, all running at once:
+
+| id | Enum | Controller | Type id | Nodes | Cards |
+|---:|---|---|---:|---:|---:|
+| 0 | `eUnknownRouter` | Nucleus 2 | 605 | 15 | 12 |
+| 1 | `eCygnusRouter` | Nucleus 2 | 605 | 15 | 12 |
+| 2 | `ePyxisRouter` | Nucleus 2 | 605 | 15 | 12 |
+| 3 | `eSirius800Router` | Nucleus 2 | 605 | 15 | 12 |
+| 4 | `eVegaRouter` | **Vega Controller** | **705** | **6** | **0** |
+
+The node tables for 0, 1, 2 and 3 are byte-identical. Only 4 differs, and it
+differs completely:
 
 ```
-# Unpack the vendor simulator somewhere writable and run it as a Sirius 800.
-CENTRA_SIMULATED_ROUTER=3 CentraController.exe        # RollCall IPShare on 2057
-dhs consumer rollcall info 127.0.0.1:2057
+id 0-3 (Nucleus 2)                      id 4 (Vega)
+0    0000-08-00   Nucleus 2             0    0000-08-00   Vega Controller
+1    0000-11-00   Router Matrix         1    0000-0A-00   Vega 2RU
+2    0000-12-00   Router Matrix         2    0000-11-00   Router Matrix
+3-6  0000-41..44  4 input cards         3    0000-12-00   Router Matrix
+7-12 0000-61..66  6 output cards        4    0000-80-00   TIELINES
+13   0000-80-00   TIELINES              5    0000-81-00   XY Panel
+14   0000-81-00   XY Panel
 ```
+
+Three things follow, and each of them cost us a wrong conclusion once:
+
+1. **`CENTRA_SIMULATED_CARDS` is ignored by the Vega.** A Vega is a
+   self-contained 2RU router rather than a card frame, so it has no card slots
+   to simulate and the twenty-four-character string does nothing. Vary the id
+   and the cards together and neither variable can be read.
+
+2. **The unit address is stable where the slot number is not.** The XY Panel is
+   `0000-81-00` on both, but it is slot 14 on a Nucleus and slot 5 on a Vega.
+   Anything keyed on a slot number breaks between models. This is why a slot's
+   identity carries its address (#1037).
+
+3. **The router *model* does not come from the id at all.** Matrices, levels,
+   sizes, salvos and names are identical on every id — two matrices, five
+   levels, 10x10 each, four salvos, 100 devices — because they are read from
+   the persisted `LocalRouter.dat`, `Persistence_*.dat` and
+   `CentraController.dccp_config` that ship inside the zip. The id names the
+   chassis; persistence holds the plant.
+
+**The persistence is also the trap.** A folder that has already run keeps the
+model it wrote, so changing the id in place can change nothing observable. Our
+first comparison did exactly that — reused one folder, tried 2 against 3, and
+concluded the id changes nothing. Two errors at once: a stale folder, and a
+pair of ids that happen to be identical anyway. Unpack a fresh copy per id.
+
+## 12. Reproducing it
+
+One instance:
+
+```
+# Unpack the vendor simulator somewhere writable, one copy per configuration.
+CENTRA_SIMULATED_ROUTER=3 CentraController.exe        # RollCall IPShare on 2057
+dhs consumer rollcall info 127.0.0.1 --port 2057
+```
+
+Several at once, which is how the table above was measured. Nothing in the
+protocol or the controller objects to it; the ports simply have to differ, and
+there are four of them in `config.xml`, not one:
+
+| `config.xml` element | What it is | Must be unique |
+|---|---|---|
+| `RollCall/SharePort` | the IPShare port a client connects to | yes |
+| `RollCall/BridgePort` | RollCall bridging between controllers | yes |
+| `IP/Adapter/Port` | DCCP, the controller's own peer link | yes |
+| `Web/XPCPort` | the web UI | yes |
+
+Missing any one of them leaves the second instance up but silently crippled.
+`SharePort` alone is not enough.
+
+```
+# five instances, ids 0..4, one folder each
+simR0/config.xml: SharePort 2050  BridgePort 2650  IP/Adapter/Port 2020  XPCPort 8050
+...
+simR4/config.xml: SharePort 2054  BridgePort 2654  IP/Adapter/Port 2024  XPCPort 8054
+```
+
+**The IPShare wedges under connection churn.** Our CLI opens a fresh connection
+per verb, and roughly the third or fourth in quick succession gets accepted at
+TCP and then never answered: `handshake: reply timeout: GETDEVINFO after 3s`,
+repeatable, cleared only by restarting the controller. Leave several seconds
+between verbs against a simulator, or drive one connection through a script.
+This is a property of the vendor's gateway rather than of the protocol, but it
+shapes how the emulator tier is driven.
 
 The simulator writes `FCSendRetValue: WARNING - command not valid` to stdout
 for every routing command it refuses, which is a useful confirmation that a

--- a/internal/snell-rollcall/docs/runbook.md
+++ b/internal/snell-rollcall/docs/runbook.md
@@ -1,0 +1,220 @@
+# RollCall — operational runbook
+
+What to run, in what order, and what the answers mean. For the wire format see
+[../CLAUDE.md](../CLAUDE.md); for measured device behaviour see
+[oracle-centra.md](oracle-centra.md).
+
+---
+
+## 1. Bring-up, in order
+
+Each step tells you something the next one needs. Stopping at the first failure
+is the point.
+
+```
+dhs consumer rollcall info <host>
+```
+
+| What you see | What it means |
+|---|---|
+| `slots N` and a status line per slot | The link, the handshake, the map service and the session service all work. Go on. |
+| `dial …: connection refused` | Nothing is listening. A frame listens on 2050; a Centra's IPShare port is configurable and is often **2057**. |
+| `handshake …: reply timeout` | Something accepted TCP and did not answer a device enquiry. Wrong port, or a device that is not RollCall. |
+| `call …: NACK` | The unit refused the session. Almost always a service it does not have — see §4. |
+| `port list …: INVSESS` | The map service was asked for on a session that did not negotiate it. A bug on our side; report it. |
+
+Then walk one node:
+
+```
+dhs consumer rollcall walk <host> --slot 1
+```
+
+A frame's cards answer with tens to hundreds of objects. A router node answers
+with two or three, and that is correct: routing is not in the menu.
+
+## 2. Slots
+
+A slot number is a position in the device's own enumeration, and the address
+behind it comes from the device. Two shapes exist and the difference matters:
+
+- **A frame** enumerates the ports of one unit. Slot 0 is the first card.
+- **A controller** enumerates units: the matrices, the tielines engine, the
+  panel driver that serves routing, and every card in the frames it fronts.
+  Slot 9 might be `0000-81-00`, the XY Panel.
+
+`info` prints each slot's identity, and the address is in the JSON:
+
+```
+dhs consumer rollcall info <host> --output json | jq '.slot_status[] | {slot, identity}'
+```
+
+## 3. Verbs
+
+### Consumer
+
+| Verb | What it does | Notes |
+|---|---|---|
+| `info <host>` | identity, slot count, per-slot status | costs one enumeration |
+| `walk <host> --slot N` | every object on a node | caches the menu for label lookups |
+| `get <host> --slot N --label X` | read one object | `--id` takes the command number instead |
+| `set <host> --slot N --label X --value V` | write one object | answers with the **stored** value |
+| `reset <host> --slot N --label X` | ask the device for its own default | the numeric field is ignored |
+| `watch <host> --slot N` | subscribe to value changes | opens the back channel |
+| `router <host>` | find and print a routing interface | probes every node unless `--slot` |
+| `route <host> --matrix M --level L --dest D [--source S]` | read or make a crosspoint | waits for the tally |
+| `tally <host> --matrix M --level L [--names]` | print a level, then follow it | Ctrl+C to stop |
+
+### Producer
+
+```
+dhs producer rollcall serve --tree tree.json --port 2050
+```
+
+Serves a canonical tree as a gateway: the root is the frame, each child is a
+card slot. See [provider.md](provider.md).
+
+## 4. When a session is refused
+
+`SP_NACK` to a call is the commonest failure and it has three usual causes.
+
+**A service the peer does not have.** Services are all-or-nothing: naming one
+the unit lacks refuses the whole call. Our consumer intersects what it wants
+with what the peer advertised, so this should not happen — but if a unit
+advertises a service and then refuses it, that is a compliance event
+(`rollcall_long_strings_refused` is the one we have seen) and the fallback is
+automatic.
+
+**The unit is out of sessions.** Servers do not time idle sessions out. The
+vendor's own comments say units "don't time them out very well (at all), and
+then run out of available sessions". A unit that has been talked to by a
+crashed client stays that way until it reboots. The specification has
+`SP_BUSY` for this; the Centra sends `SP_NACK` instead, so a refusal is worth
+retrying before it is believed.
+
+**A user level the unit does not accept.** Four exist: engineer, operator,
+supervisor, factory. We ask for supervisor.
+
+## 5. Reading a capture
+
+The dissector is at
+[`wireshark/dhs_snell_rollcall.lua`](../wireshark/dhs_snell_rollcall.lua).
+Install it per [docs/wireshark.md](../../../docs/wireshark.md), then:
+
+| Question | Filter |
+|---|---|
+| All RollCall traffic | `dhs_snell_rollcall` |
+| Who opened what | `dhs_snell_rollcall.type == 2` |
+| One node only | `dhs_snell_rollcall.dst.unit == 0x81` |
+| Crosspoints | `dhs_snell_rollcall.source_pin` |
+| Tally, not replies | `dhs_snell_rollcall.flags.back_channel == 1` |
+| Refusals | `dhs_snell_rollcall.type in {0 14 15 23}` |
+
+A refusal type says which kind: `NACK` is "I understood and will not",
+`INVCMD` is "I do not know this message", `INVSESS` is "not on this session",
+`BUSY` is "try again".
+
+## 6. Routers
+
+Find the interface first. It is on one node and nothing in a device list says
+which:
+
+```
+dhs consumer rollcall router <host>
+```
+
+If that reports nothing, the device has no routing interface — a frame of cards
+does not. If it reports one, everything else follows from the matrices and
+levels it printed.
+
+**Three behaviours that surprise people**, all measured:
+
+1. **The reply to a route carries the previous crosspoint.** The result code
+   says whether it worked; the new value arrives afterwards on the back
+   channel. The `route` verb waits for it, so what it prints is what happened.
+
+2. **The tally follows tielines.** Ask for source 7 and read back matrix 2
+   source 1: the number reported is the *final upstream* source. The router is
+   working. Reading back what you wrote is not a valid expectation.
+
+3. **Subscribing does not fill in the picture.** Enabling the back channel does
+   not replay current state on a real controller, whatever the specification
+   says. Read the level once, then follow it. `tally` does both.
+
+Names come in bulk from files, verified by a checksum computed from the names
+themselves. Where a controller names a file its own file service will not serve
+— which the Centra does, because the path is in the controller's filesystem and
+each node's file service is rooted at its own directory — the names are read one
+command at a time and `rollcall_names_file_unreadable` is recorded. On a large
+level that is slow, and the event is there to explain why.
+
+## 7. Compliance events
+
+The connector absorbs a deviation and keeps working, then counts it. One entry
+per kind with the most recent detail, never one per occurrence.
+
+| Event | What it means |
+|---|---|
+| `rollcall_long_strings_refused` | A unit advertised the 32-bit generation and refused a call asking for it. We fell back. |
+| `rollcall_menu_span_overruns` | A container claimed a subtree longer than the menu holding it. Clamped. |
+| `rollcall_menu_count_mismatch` | A device announced one number of menu lines and sent another. |
+| `rollcall_duplicate_command` | Two menu lines claimed the same command number. |
+| `rollcall_access_gated` | A line was replaced by the placeholder a server substitutes above a user level. Not a fault. |
+| `rollcall_value_mode_empty` | A value reply set no flag, so it carried nothing. |
+| `rollcall_unsolicited_command` | A push named a command the walked menu does not list. Delivered anyway. |
+| `rollcall_display_line_out_of_range` | A status line outside the four and the two priorities. |
+| `rollcall_unlisted_node` | A slot was addressed that the enumeration did not mention. Addressed anyway. |
+| `rollcall_names_checksum_mismatch` | A names file did not hash to its published checksum. Names kept. |
+| `rollcall_names_file_unreadable` | A router named a names file it will not serve. Fell back to one command per name. |
+
+The provider has its own set, in [provider.md](provider.md).
+
+## 8. Integration runs
+
+```
+# loopback only
+ansible-playbook -i inventory/hosts.ini playbooks/snell-rollcall-integration.yml
+
+# with the vendor Centra emulator
+ROLLCALL_SIM_HOST=127.0.0.1 ROLLCALL_SIM_PORT=2057 ansible-playbook ...
+
+# with a live device, read-only
+ROLLCALL_TEST_HOST=10.6.250.105 ansible-playbook ...
+```
+
+The emulator lives in [`assets/Emulator/RouterSimulator`](../assets/Emulator/RouterSimulator).
+Unpack it somewhere writable — one copy per configuration — and run
+`CentraController.exe`.
+
+`CENTRA_SIMULATED_ROUTER` selects the chassis. Ids 0 to 3 all answer as a
+`Nucleus 2` with fifteen nodes and are indistinguishable on the wire; only 4
+differs, giving a `Vega Controller` with six nodes and no cards, which also
+makes it ignore `CENTRA_SIMULATED_CARDS`. The zip ships persistence, so a
+folder that has already run keeps the model it wrote: change the id in a fresh
+copy, never in place. [oracle-centra.md](oracle-centra.md) §11 has the measured
+table.
+
+Several instances run side by side happily — that is how the table was
+measured — but four ports in `config.xml` have to differ, not one:
+`RollCall/SharePort`, `RollCall/BridgePort`, `IP/Adapter/Port` and
+`Web/XPCPort`. Missing one leaves the second instance up and silently
+crippled.
+
+The IPShare wedges under connection churn: our CLI opens a fresh connection per
+verb, and roughly the third in quick succession is accepted at TCP and never
+answered. Leave a few seconds between verbs, or restart the controller.
+
+It writes `FCSendRetValue: WARNING - command not valid` to stdout for every
+routing command it refuses, which is a quick way to tell a Full Control refusal
+from a session-layer one.
+
+## 9. Known device quirks
+
+| Device | What it does | What we do |
+|---|---|---|
+| Centra | No display service; refuses any call naming it | Ask only for what a peer advertises |
+| Centra | Nodes differ by unit, not port | Address by the enumeration's own address |
+| Centra | Cards answer command 100 with their model number as a string | Require a numeric interface version |
+| Centra | Directory entries are variable-length, not the declared 13-byte field | Read the name as what follows the header |
+| Centra | Names files named in its own filesystem, unreachable over RollCall | Fall back to one command per name |
+| Centra | Enabling the back channel replays nothing | Read the state, then follow it |
+| Any unit | Sessions are not timed out | Always send `SP_TERM`; a leaked session is held until reboot |


### PR DESCRIPTION
Four documents an operator reads in order: what the connector is, what to run and what the answers mean, how the outbound side behaves, and what the vendor controller actually did when we measured it.

## The runbook is the load-bearing one

Bring-up in the order where each step tells you something the next one needs; the three usual causes of a refused session; Wireshark filters that answer a question rather than showing everything; the compliance-event table.

## The oracle document gains the knob that decides what the emulator is

Our first attempt to characterise `CENTRA_SIMULATED_ROUTER` got it wrong twice over. It is written down that way, because both mistakes are the ones anyone repeating this will make.

Measured across five clean copies, one per id, all running at once:

| id | Enum | Controller | Nodes | Cards |
|---:|---|---|---:|---:|
| 0 | `eUnknownRouter` | Nucleus 2 | 15 | 12 |
| 1 | `eCygnusRouter` | Nucleus 2 | 15 | 12 |
| 2 | `ePyxisRouter` | Nucleus 2 | 15 | 12 |
| 3 | `eSirius800Router` | Nucleus 2 | 15 | 12 |
| 4 | `eVegaRouter` | **Vega Controller** | **6** | **0** |

The node tables for 0–3 are byte-identical. Only 4 differs.

**Mistake one:** we compared 2 against 3 — two identical configurations — and concluded the id changes nothing.

**Mistake two:** we reused a folder that had already run. The zip ships `LocalRouter.dat`, `Persistence_*.dat` and `CentraController.dccp_config`, so a folder keeps the model it wrote and changing the id in place can change nothing observable even when the id does matter. Unpack a fresh copy per id.

Three consequences, each of which cost a wrong conclusion:

1. `CENTRA_SIMULATED_CARDS` does nothing on a Vega — it is a self-contained 2RU router with no card slots.
2. The unit address is stable where the slot number is not. The XY Panel is `0000-81-00` on both models, but slot 14 on a Nucleus and slot 5 on a Vega. Anything keyed on a slot number breaks between models — the reason for #1037.
3. The router *model* — matrices, levels, sizes, salvos, names — comes from persistence rather than from the id, and is identical on all five. That half of the first comparison was right.

## Also recorded

- Several instances run side by side, which is how the table was measured — but **four** ports in `config.xml` have to differ, not one: `RollCall/SharePort`, `RollCall/BridgePort`, `IP/Adapter/Port`, `Web/XPCPort`. Missing one leaves the second instance up and silently crippled.
- The IPShare wedges after roughly three connections in quick succession: accepted at TCP, never answered, cleared only by a restart. A property of the vendor gateway, but it shapes how the emulator tier is driven.

Section numbering fixed — there were two section 9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)