### PR TITLE
feat(snell-rollcall): canonical export and per-card device models

### DIFF
--- a/cmd/dhs/cmd_extract.go
+++ b/cmd/dhs/cmd_extract.go
@@ -102,6 +102,10 @@ func runExtract(ctx context.Context, args []string) error {
 		return fmt.Errorf("canonical capture: %w", err)
 	}
 
+	// Everything that writes to the capture directory is finished with, so the
+	// recorder can be closed before anything is renamed.
+	cleanup()
+
 	// Rename raw.<transport>.jsonl → wire.jsonl so the fixture layout
 	// matches docs/adr/0020-capture-and-fixture-layout.md (+ tests/fixtures/products/README.md) exactly (the protocol is still
 	// identifiable via meta.json). Best-effort: a missing raw file

--- a/cmd/dhs/cmd_walk.go
+++ b/cmd/dhs/cmd_walk.go
@@ -9,11 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"dhs/internal/acp1/consumer"
 	"dhs/internal/acp2/consumer"
 	"dhs/internal/consumer"
 	"dhs/internal/emberplus/consumer"
 	"dhs/internal/export"
+	"dhs/internal/export/canonical"
 )
 
 func runWalk(ctx context.Context, args []string) error {
@@ -199,22 +199,20 @@ func runWalk(ctx context.Context, args []string) error {
 // canonical `tree.json` in the same schema; Ember+ additionally
 // writes `glow.json` for wire-level cross-checking.
 func writeCanonicalCapture(ctx context.Context, dir string, plug consumer.Protocol, cf *commonFlags) error {
-	switch p := plug.(type) {
-	case *emberplus.Plugin:
+	// Ember+ writes glow.json beside the tree, so it keeps its own path.
+	if p, ok := plug.(*emberplus.Plugin); ok {
 		return writeEmberplusCapture(ctx, dir, p, cf)
-	case *acp1.Plugin:
-		return writeACP1Capture(ctx, dir, p)
-	case *acp2.Plugin:
-		return writeACP2Capture(ctx, dir, p)
 	}
-	return nil
-}
 
-// writeACP2Capture writes `tree.json` in canonical shape for an ACP2
-// device. Mirrors writeACP1Capture: the raw AN2 frame log (recorder)
-// is appended alongside by the transport layer; this function covers
-// only the decoded canonical export.
-func writeACP2Capture(ctx context.Context, dir string, p *acp2.Plugin) error {
+	// Everything else that can describe itself does, by the method rather than
+	// by its type. A type switch here silently produced no tree.json for every
+	// connector nobody had remembered to add — which is how a capture ends up
+	// with frames and no model.
+	p, ok := plug.(canonicalizer)
+	if !ok {
+		return nil
+	}
+
 	tree, err := p.Canonicalize(ctx)
 	if err != nil {
 		return fmt.Errorf("canonicalize: %w", err)
@@ -231,26 +229,12 @@ func writeACP2Capture(ctx context.Context, dir string, p *acp2.Plugin) error {
 	return nil
 }
 
-// writeACP1Capture writes `tree.json` in canonical shape for an ACP1
-// device. The raw frame log (recorder) is already appended alongside
-// by the transport layer; this function covers only the decoded
-// canonical export.
-func writeACP1Capture(ctx context.Context, dir string, p *acp1.Plugin) error {
-	tree, err := p.Canonicalize(ctx)
-	if err != nil {
-		return fmt.Errorf("canonicalize: %w", err)
-	}
-	f, err := os.Create(filepath.Join(dir, "tree.json"))
-	if err != nil {
-		return fmt.Errorf("create tree.json: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	if err := export.WriteCanonicalJSON(ctx, f, tree); err != nil {
-		return fmt.Errorf("write tree.json: %w", err)
-	}
-	fmt.Printf("capture: wrote tree.json to %s\n", dir)
-	return nil
+// canonicalizer is a plugin that can describe what it has walked.
+type canonicalizer interface {
+	Canonicalize(ctx context.Context) (*canonical.Export, error)
 }
+
+
 
 // writeEmberplusCapture dumps glow.json (lossless decoded Glow tree)
 // and tree.json (canonical Export) into dir alongside the raw frame

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,7 +93,7 @@ concerns here.
 
 | Folder | State |
 |---|---|
-| `internal/snell-rollcall/` | **in progress** (epic #1009, gate lifted by the owner 2026-09-07). The ADR-0025 step-1 audit is done and the wire is validated against a live oracle on `10.6.250.105` — consumer read/write/subscribe proven against the real stack, and a throwaway producer spike rendered and driven by RollCall Control Panel 4.12.48. Landed so far: `CLAUDE.md` (wire context) + `docs/` (audit, DM/UI analysis, 1 623 captured frames, 560 menu lines). Still to come, one PR each: `codec/` · `session/` · `consumer/` · `provider/` · `wireshark/` · `integration/` · `testdata/`. No Go code and no registry entry yet. |
+| `internal/snell-rollcall/` | **shipping the connector** (epic #1009). Consumer, provider, session layer and codec are all at 100% statement coverage with CI floors, registered in both registries, and driven from the CLI. Both wire generations are served from one model. Router control implements the Full Control command set — discovery, matrices, levels, names in bulk, crosspoints, protects, salvos, tally — and every offset in it is measured against the vendor Centra controller running as a Sirius 800 (`docs/oracle-centra.md`). Ships `wireshark/dhs_snell_rollcall.lua` with a replay test over 90 KB of captured live traffic, and an Ansible integration play with an emulator tier, a read-only live-device tier and a loopback tier. Outstanding: a DM/manifest generator and the per-product fixture set. |
 | `internal/cerebrum-nb/provider/` | **consumer-only by design at this stage** — only the consumer + codec + wireshark layers are shipped; no `provider/` folder exists yet on disk. Intentionally not in scope at the current stage per `internal/cerebrum-nb/CLAUDE.md`. |
 
 ---

--- a/internal/snell-rollcall/consumer/canonicalize.go
+++ b/internal/snell-rollcall/consumer/canonicalize.go
@@ -1,0 +1,289 @@
+package rollcall
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dhs/internal/consumer"
+	"dhs/internal/export/canonical"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// Canonicalize turns what has been walked into a canonical export.
+//
+// It is the reverse of what the provider does, and the two are meant to meet
+// in the middle: a tree served as a RollCall device, walked back, should
+// describe the same objects. That round trip is what makes a device model
+// worth caching — walk a card once, keep the tree, and every later session
+// resolves a label without asking the device again.
+//
+// Shape:
+//
+//	device (Node, oid="1", identifier=host)
+//	├── slot-0 (Node)
+//	│   ├── <container> (Node)      a menu line with a subtree
+//	│   │   └── <object> (Parameter)
+//	│   └── <object> (Parameter)    a menu line with a command
+//	└── slot-N ...
+//
+// Only slots already walked appear. A container in RollCall is a menu line
+// whose step spans a subtree, so the nesting here is the nesting the device
+// published rather than one imposed on it.
+func (p *Plugin) Canonicalize(ctx context.Context) (*canonical.Export, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("rollcall: canonicalize: %w", err)
+	}
+
+	p.mu.RLock()
+	host := p.addr
+	trees := make(map[int]*slotTree, len(p.trees))
+	for slot, t := range p.trees {
+		trees[slot] = t
+	}
+	p.mu.RUnlock()
+
+	slots := make([]int, 0, len(trees))
+	for slot := range trees {
+		slots = append(slots, slot)
+	}
+	sort.Ints(slots)
+
+	children := make([]canonical.Element, 0, len(slots))
+	for _, slot := range slots {
+		children = append(children, slotNode(slot, trees[slot]))
+	}
+
+	identifier := "device"
+	if host != "" {
+		identifier = host
+	}
+
+	root := &canonical.Node{
+		Header: canonical.Header{
+			Number:     1,
+			Identifier: identifier,
+			Path:       identifier,
+			OID:        "1",
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+			Children:   children,
+		},
+	}
+	if len(children) == 0 {
+		root.Children = canonical.EmptyChildren()
+	}
+	return &canonical.Export{Root: root}, nil
+}
+
+// slotNode builds one slot from its walked menu.
+func slotNode(slot int, t *slotTree) *canonical.Node {
+	ident := "slot-" + strconv.Itoa(slot)
+	oid := "1." + strconv.Itoa(slot+1)
+
+	node := &canonical.Node{
+		Header: canonical.Header{
+			Number:     slot,
+			Identifier: ident,
+			Path:       ident,
+			OID:        oid,
+			IsOnline:   true,
+			Access:     canonical.AccessRead,
+			Children:   canonical.EmptyChildren(),
+		},
+	}
+
+	// The roots of the menu are the lines nothing else contains.
+	contained := make(map[int]bool, len(t.lines))
+	for _, line := range t.lines {
+		for _, child := range line.children {
+			contained[child] = true
+		}
+	}
+
+	var elems []canonical.Element
+	for i := range t.lines {
+		if contained[i] {
+			continue
+		}
+		elems = append(elems, menuElement(t, i, ident, oid, len(elems)+1))
+	}
+	if len(elems) > 0 {
+		node.Children = elems
+	}
+	return node
+}
+
+// menuElement turns one menu line into a canonical element: a node when it
+// contains others, a parameter when it carries a value.
+func menuElement(t *slotTree, index int, parentPath, parentOID string, number int) canonical.Element {
+	line := t.lines[index]
+
+	ident := line.Text
+	if ident == "" {
+		ident = "line-" + strconv.FormatUint(uint64(line.Index), 10)
+	}
+	path := parentPath + "." + ident
+	oid := parentOID + "." + strconv.Itoa(number)
+
+	header := canonical.Header{
+		Number:     number,
+		Identifier: ident,
+		Path:       path,
+		OID:        oid,
+		IsOnline:   true,
+		Access:     accessOf(line.Style),
+	}
+
+	if len(line.children) > 0 {
+		children := make([]canonical.Element, 0, len(line.children))
+		for _, child := range line.children {
+			children = append(children, menuElement(t, child, path, oid, len(children)+1))
+		}
+		// A container holds things rather than a value of its own.
+		header.Access = canonical.AccessRead
+		header.Children = children
+		return &canonical.Node{Header: header}
+	}
+
+	// A line with no command and no children is a separator or a placeholder
+	// the server substituted for something above this user level. It names
+	// nothing that can be read, so it is a node rather than a parameter.
+	if line.Command == 0 {
+		header.Children = canonical.EmptyChildren()
+		return &canonical.Node{Header: header}
+	}
+
+	return parameterFor(line, header)
+}
+
+// parameterFor maps a menu line onto a canonical parameter.
+func parameterFor(line menuLine, header canonical.Header) *canonical.Parameter {
+	param := &canonical.Parameter{Header: header}
+
+	switch styleKind(line.Style) {
+	case consumer.KindBool:
+		param.Type = canonical.ParamBoolean
+		param.Value = false
+
+	case consumer.KindString:
+		param.Type = canonical.ParamString
+		param.Value = ""
+		if line.MaxRange > 0 {
+			param.Maximum = float64(line.MaxRange)
+		}
+
+	default:
+		// A divisor means the device is carrying a real as a scaled integer,
+		// and the canonical form says so with a factor rather than by
+		// pre-dividing: the wire value stays recoverable.
+		if line.DivScale > 1 {
+			param.Type = canonical.ParamReal
+			factor := int64(line.DivScale)
+			param.Factor = &factor
+			param.Value = 0.0
+			param.Minimum = float64(line.MinRange) / float64(line.DivScale)
+			param.Maximum = float64(line.MaxRange) / float64(line.DivScale)
+			if line.Step > 0 {
+				param.Step = float64(line.Step) / float64(line.DivScale)
+			}
+		} else {
+			param.Type = canonical.ParamInteger
+			param.Value = int64(0)
+			param.Minimum = float64(line.MinRange)
+			param.Maximum = float64(line.MaxRange)
+			if line.Step > 0 {
+				param.Step = float64(line.Step)
+			}
+		}
+	}
+
+	// The format string is the only place a unit can travel on this protocol,
+	// so it is kept whole rather than parsed for one.
+	if line.Param != "" {
+		format := line.Param
+		param.Format = &format
+	}
+	return param
+}
+
+// accessOf maps a menu line's style onto the canonical access string.
+//
+// A disabled line is one the device says may be read and not written, which is
+// what read-only means; hidden is a level gate rather than an access, and a
+// line we can see is one we may read.
+func accessOf(style codec.Style) string {
+	if style.Disabled() {
+		return canonical.AccessRead
+	}
+	switch style.Kind() {
+	case codec.StyleDisplay, codec.StyleList, codec.StyleTiled, codec.StylePartial:
+		return canonical.AccessRead
+	default:
+		return canonical.AccessReadWrite
+	}
+}
+
+// ExportCanonical is Canonicalize under the name the device-model cache asks
+// for. The cache and the capture want the same thing and there is no reason to
+// build it twice.
+func (p *Plugin) ExportCanonical(ctx context.Context) (*canonical.Export, error) {
+	return p.Canonicalize(ctx)
+}
+
+// IdentityProbe names the card in a slot, so one device model is kept per card
+// type rather than per slot: a frame with twelve identical cards walks one of
+// them and reads the model back eleven times.
+//
+// The name a unit reports is not the key. It is user-editable — an operator
+// calls one card "CAM 1 PROC" and the identical card beside it "SPARE" — and
+// two cards with different labels have the same command set. What identifies a
+// model is the type the vendor assigned and the command set the firmware
+// implements, which is exactly what the specification says: a unit's ID plus
+// its command set determine what commands exist.
+//
+// It costs one message. A walk here would be minutes on a large card, and this
+// runs before anything else wants the link.
+func (p *Plugin) IdentityProbe(ctx context.Context, slot int) (string, error) {
+	s, err := p.session(ctx, slot)
+	if err != nil {
+		return "", err
+	}
+
+	reply, err := s.Do(ctx, codec.MsgGetID, nil)
+	if err != nil {
+		return "", fmt.Errorf("rollcall: identity of slot %d: %w", slot, err)
+	}
+	id, err := codec.DecodeID(reply.Payload)
+	if err != nil {
+		return "", fmt.Errorf("rollcall: identity of slot %d: %w", slot, err)
+	}
+
+	// A type the vendor's table does not list still names itself by its
+	// number, which identifies the model just as well and is better than
+	// inventing a word for it.
+	product := codec.UnitTypeName(id.TypeID)
+
+	return fmt.Sprintf("%s@%d.%d.cs%d",
+		identityToken(product), id.Version.Major, id.Version.Minor, id.Version.CmdSet), nil
+}
+
+// identityToken makes a vendor type name safe to use as a filename.
+//
+// The names in the vendor's table carry spaces, dots and slashes — "4929 AES
+// O/P card" is one of them — and the identity becomes a path under .cache/dm.
+func identityToken(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/snell-rollcall/consumer/canonicalize_test.go
+++ b/internal/snell-rollcall/consumer/canonicalize_test.go
@@ -1,0 +1,307 @@
+package rollcall
+
+import (
+	"context"
+	"testing"
+
+	"dhs/internal/export/canonical"
+	"dhs/internal/snell-rollcall/codec"
+)
+
+// The canonical export is the reverse of what the provider does, and the two
+// are meant to meet in the middle: a tree served as a RollCall device and
+// walked back should describe the same objects.
+
+func TestCanonicalizeARollCallDevice(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	exp, err := h.plugin.Canonicalize(ctx)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+
+	root := exp.Root.Common()
+	if root.Identifier != "10.6.250.105" {
+		t.Errorf("root = %q, want the host", root.Identifier)
+	}
+	if len(root.Children) != 1 {
+		t.Fatalf("%d slots, want the one that was walked", len(root.Children))
+	}
+
+	slot := root.Children[0].Common()
+	if slot.Identifier != "slot-1" || slot.Number != 1 {
+		t.Errorf("slot = %q number %d", slot.Identifier, slot.Number)
+	}
+
+	// The test menu is a container with three lines under it and one beside
+	// it, and the nesting is what the device published rather than one
+	// imposed on it.
+	if len(slot.Children) != 2 {
+		t.Fatalf("%d roots under the slot, want the container and the line beside it",
+			len(slot.Children))
+	}
+
+	video := slot.Children[0].Common()
+	if video.Identifier != "Video" || len(video.Children) != 3 {
+		t.Fatalf("container = %q with %d children", video.Identifier, len(video.Children))
+	}
+	if video.Access != canonical.AccessRead {
+		t.Errorf("a container is not writable, but its access is %q", video.Access)
+	}
+
+	// A real is carried as a scaled integer, and the canonical form says so
+	// with a factor rather than by pre-dividing: the wire value stays
+	// recoverable.
+	gain, ok := video.Children[0].(*canonical.Parameter)
+	if !ok {
+		t.Fatalf("gain came back as %T", video.Children[0])
+	}
+	if gain.Type != canonical.ParamReal {
+		t.Errorf("gain is %q, want a real", gain.Type)
+	}
+	if gain.Factor == nil || *gain.Factor != 10 {
+		t.Errorf("gain factor = %v, want 10", gain.Factor)
+	}
+	if gain.Minimum != -6.0 || gain.Maximum != 0.6 {
+		t.Errorf("gain range = %v..%v, want the scaled -6..0.6", gain.Minimum, gain.Maximum)
+	}
+	if gain.Format == nil || *gain.Format != "%0.1f dB" {
+		t.Errorf("gain format = %v; the format string is the only place a unit travels", gain.Format)
+	}
+	if gain.Access != canonical.AccessReadWrite {
+		t.Errorf("gain access = %q", gain.Access)
+	}
+
+	enable, ok := video.Children[1].(*canonical.Parameter)
+	if !ok || enable.Type != canonical.ParamBoolean {
+		t.Errorf("enable came back as %T %v", video.Children[1], enable)
+	}
+
+	name, ok := video.Children[2].(*canonical.Parameter)
+	if !ok || name.Type != canonical.ParamString {
+		t.Fatalf("name came back as %T", video.Children[2])
+	}
+	if name.Maximum != 32.0 {
+		t.Errorf("a string's range is a length: %v", name.Maximum)
+	}
+
+	// A display line may be read and not written.
+	status, ok := slot.Children[1].(*canonical.Parameter)
+	if !ok {
+		t.Fatalf("status came back as %T", slot.Children[1])
+	}
+	if status.Access != canonical.AccessRead {
+		t.Errorf("a display line is read-only, but its access is %q", status.Access)
+	}
+}
+
+func TestCanonicalizeADeviceNobodyWalked(t *testing.T) {
+	h := newHarness(t, nil)
+
+	exp, err := h.plugin.Canonicalize(context.Background())
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	root := exp.Root.Common()
+	if len(root.Children) != 0 {
+		t.Errorf("%d slots on a device nothing has walked", len(root.Children))
+	}
+	// An empty children slice rather than a nil one, so the JSON has a key.
+	if root.Children == nil {
+		t.Error("children should be present and empty")
+	}
+}
+
+func TestCanonicalizeWithoutAConnection(t *testing.T) {
+	p := New(testDeps())
+
+	exp, err := p.Canonicalize(context.Background())
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	if exp.Root.Common().Identifier != "device" {
+		t.Errorf("a plugin with no host names itself %q", exp.Root.Common().Identifier)
+	}
+}
+
+func TestCanonicalizeStopsWithItsContext(t *testing.T) {
+	h := newHarness(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := h.plugin.Canonicalize(ctx); err == nil {
+		t.Error("a cancelled context should stop the export")
+	}
+}
+
+func TestExportCanonicalIsTheSameThing(t *testing.T) {
+	// The device-model cache and the capture want the same export, and there
+	// is no reason to build it twice.
+	h := newHarness(t, func(d *device) { d.setMenu(1, testMenu()) })
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	a, err := h.plugin.Canonicalize(ctx)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+	b, err := h.plugin.ExportCanonical(ctx)
+	if err != nil {
+		t.Fatalf("ExportCanonical: %v", err)
+	}
+	if len(a.Root.Common().Children) != len(b.Root.Common().Children) {
+		t.Error("the two exports describe different devices")
+	}
+}
+
+func TestALineWithNoValueBecomesANode(t *testing.T) {
+	// A line with no command and no children is a separator, or the
+	// placeholder a server substitutes for something above this user level. It
+	// names nothing that can be read.
+	h := newHarness(t, func(d *device) {
+		d.setMenu(1, []codec.MenuItem{
+			{MenuIndex: 0, Style: codec.StyleDisplay | codec.StyleDisabled, Text: "Reserved"},
+			{MenuIndex: 1, Style: codec.StyleNumber, Command: 5, Text: "",
+				MinRange: 0, MaxRange: 100, Step: 5},
+		})
+	})
+	ctx := context.Background()
+
+	if _, err := h.plugin.Walk(ctx, 1); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	exp, err := h.plugin.Canonicalize(ctx)
+	if err != nil {
+		t.Fatalf("Canonicalize: %v", err)
+	}
+
+	slot := exp.Root.Common().Children[0].Common()
+	if len(slot.Children) != 2 {
+		t.Fatalf("%d lines, want 2", len(slot.Children))
+	}
+	if _, ok := slot.Children[0].(*canonical.Node); !ok {
+		t.Errorf("a line with no command came back as %T", slot.Children[0])
+	}
+	// A line with no label is named by its index, because something has to
+	// name it and inventing a word would be worse.
+	if got := slot.Children[1].Common().Identifier; got != "line-1" {
+		t.Errorf("an unnamed line is called %q", got)
+	}
+
+	// An integer without a divisor keeps its step as the device gave it.
+	step, ok := slot.Children[1].(*canonical.Parameter)
+	if !ok {
+		t.Fatalf("the numeric line came back as %T", slot.Children[1])
+	}
+	if step.Type != canonical.ParamInteger || step.Step != 5.0 {
+		t.Errorf("the numeric line is %q with step %v", step.Type, step.Step)
+	}
+}
+
+func TestAccessFollowsTheStyle(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		style codec.Style
+		want  string
+	}{
+		{"a number may be written", codec.StyleNumber, canonical.AccessReadWrite},
+		{"a checkbox may be written", codec.StyleCheckbox, canonical.AccessReadWrite},
+		{"an editable string may be written", codec.StyleEditString, canonical.AccessReadWrite},
+		{"a display may not", codec.StyleDisplay, canonical.AccessRead},
+		{"a list may not", codec.StyleList, canonical.AccessRead},
+		{"a tiled list may not", codec.StyleTiled, canonical.AccessRead},
+		{"a partial may not", codec.StylePartial, canonical.AccessRead},
+		{"a disabled number may not", codec.StyleNumber | codec.StyleDisabled, canonical.AccessRead},
+	} {
+		if got := accessOf(tc.style); got != tc.want {
+			t.Errorf("%s: %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIdentityProbeNamesTheCardTypeNotTheLabel(t *testing.T) {
+	// Two cards of one type with different operator labels share a device
+	// model. What identifies the model is the vendor's type and the command
+	// set the firmware implements, not the name somebody typed into a panel.
+	h := newHarness(t, func(d *device) {
+		d.identity[1] = codec.ID{
+			TypeID:  623,
+			Version: codec.Version{Major: 2, Minor: 4, Alpha: ' ', CmdSet: 7},
+			Name:    "CAM 1 PROC",
+		}
+	})
+
+	got, err := h.plugin.IdentityProbe(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("IdentityProbe: %v", err)
+	}
+	want := identityToken(codec.UnitTypeName(623)) + "@2.4.cs7"
+	if got != want {
+		t.Errorf("identity = %q, want %q", got, want)
+	}
+	if got == "" || got[0] == '@' {
+		t.Errorf("identity %q has no product half", got)
+	}
+}
+
+func TestIdentityProbeOfATypeNobodyHasHeardOf(t *testing.T) {
+	h := newHarness(t, func(d *device) {
+		d.identity[1] = codec.ID{
+			TypeID:  0xFFFE,
+			Version: codec.Version{Major: 1, Alpha: ' ', CmdSet: 1},
+		}
+	})
+
+	got, err := h.plugin.IdentityProbe(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("IdentityProbe: %v", err)
+	}
+	// The number still identifies the model just as well as a name would.
+	if got != "unit-type-65534@1.0.cs1" {
+		t.Errorf("identity = %q", got)
+	}
+}
+
+func TestIdentityProbeWhenTheDeviceWillNotSay(t *testing.T) {
+	h := newHarness(t, func(d *device) { d.refuse[codec.MsgGetID] = true })
+
+	if _, err := h.plugin.IdentityProbe(context.Background(), 1); err == nil {
+		t.Error("a refused identity should reach the caller")
+	}
+
+	garbled := newHarness(t, func(d *device) { d.garble[codec.MsgGetID] = true })
+	if _, err := garbled.plugin.IdentityProbe(context.Background(), 1); err == nil {
+		t.Error("an identity that will not decode should be an error")
+	}
+
+	p := New(testDeps())
+	if _, err := p.IdentityProbe(context.Background(), 1); err == nil {
+		t.Error("an identity probe without a connection should fail")
+	}
+}
+
+func TestIdentityTokenIsSafeInAPath(t *testing.T) {
+	// The vendor's own type names carry spaces, dots and slashes — "4929 AES
+	// O/P card" is one of them — and the identity becomes a path under
+	// .cache/dm.
+	for _, tc := range []struct{ in, want string }{
+		{"4929 AES O/P card", "4929-AES-O-P-card"},
+		{"RC32 Rout. IPSh Cli", "RC32-Rout--IPSh-Cli"},
+		{"plain", "plain"},
+		{"--edges--", "edges"},
+		{"", ""},
+	} {
+		if got := identityToken(tc.in); got != tc.want {
+			t.Errorf("identityToken(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/snell-rollcall/docs/README.md
+++ b/internal/snell-rollcall/docs/README.md
@@ -1,0 +1,85 @@
+# Snell RollCall
+
+RollCall is Snell's device control protocol: units on a network, each with
+ports, each port carrying a menu of objects a client reads and writes. It is
+what an IQ frame, a Centra controller and a Sirius router all speak.
+
+| Role | Doc | State |
+|---|---|---|
+| Operator runbook | [runbook.md](runbook.md) | bring-up, verbs, what to check when it does not work |
+| Consumer | [consumer.md](consumer.md) | the outbound connector |
+| Provider | [provider.md](provider.md) | serving a canonical tree as a gateway |
+| What the wire looks like | [../CLAUDE.md](../CLAUDE.md) | wire format, quirks, what not to do |
+| Specification coverage | [spec-coverage.md](spec-coverage.md) | every message type and structure, checked by a test |
+| Measured behaviour | [oracle-centra.md](oracle-centra.md) | what a vendor controller actually does |
+| Device model and UI | [dm-and-ui.md](dm-and-ui.md) | how the tree maps to the neutral model |
+
+## The two things that make RollCall unusual
+
+**There are two wire generations and one connection carries both.** The
+original is 16-bit: command numbers and menu indices fit sixteen bits, and
+strings live in twenty-byte fixed fields. The 2014 extension widens both. Which
+one a session speaks is decided by the `SV_LONGSTR` bit in its `SP_CALL`, not by
+the device, so a client with two sessions to one unit can be speaking both at
+once. Services are granted all-or-nothing: a call naming one service the peer
+does not have is refused entirely.
+
+**A router has no menu.** Every other device describes itself through the menu
+service. A router controller serves its routing, its names, its protects and
+its salvos as control variables in a flat 32-bit command space, whose numbers a
+client works out by arithmetic from a root table at command 100. Walking a
+router's menu finds three lines and nothing useful. See
+[oracle-centra.md](oracle-centra.md) §2.
+
+## Layout
+
+```
+internal/snell-rollcall/
+  codec/          the wire format, stdlib-only (ADR-0006)
+    dtp/          Data Transfer Params, which the routing interface rides on
+    router/       the Full Control command arithmetic and its file formats
+  session/        links, sessions, channels, the back channel, keepalive
+  consumer/       the outbound connector, both generations, router control
+  provider/       serving a canonical tree as a RollCall gateway
+  wireshark/      dhs_snell_rollcall.lua — the byte-exact reference
+  integration/    replay tests against captured traffic (-tags integration)
+  testdata/       trees and fixtures
+  assets/         the specification, the vendor sources, the emulators
+```
+
+## Specification and vendor material
+
+| What | Where |
+|---|---|
+| RollCall Technical Specification Rev 14 | [`assets/Protocol/Docs`](../assets/Protocol/Docs) |
+| Full Control Command Set (routers) | [`assets/Protocol/Docs/Full Control Command Set.docx`](../assets/Protocol/Docs) |
+| Full RollCall Control of Routers (the design behind it) | same directory |
+| Vendor C sources (`FileServer.c`, `MsgHandlers.c`, …) | [`assets/Protocol/Source`](../assets/Protocol/Source) |
+| Vendor headers (`rc3comm.h`, `RC3FILE.H`, `RC3TYPES.H`) | same tree |
+| Centra controller emulator, runs as a Sirius 800 | [`assets/Emulator/RouterSimulator`](../assets/Emulator/RouterSimulator) |
+| Wireshark dissector | [`wireshark/dhs_snell_rollcall.lua`](../wireshark/dhs_snell_rollcall.lua) |
+
+When the specification, a device and our codec disagree, the dissector breaks
+the tie first: it is what you open before you open the Go code.
+
+## Quick start
+
+```
+# What is on the other end
+dhs consumer rollcall info 10.6.250.105
+
+# What one node offers
+dhs consumer rollcall walk 10.6.250.105 --slot 1
+
+# Read and write an object
+dhs consumer rollcall get 10.6.250.105 --slot 1 --label gain
+dhs consumer rollcall set 10.6.250.105 --slot 1 --label gain --value -6
+
+# A router
+dhs consumer rollcall router 10.6.250.105
+dhs consumer rollcall route  10.6.250.105 --matrix 1 --level 1 --dest 4 --source 9
+dhs consumer rollcall tally  10.6.250.105 --matrix 1 --level 1 --names
+
+# Serve a tree as a gateway
+dhs producer rollcall serve --tree tree.json --port 2050
+```

--- a/internal/snell-rollcall/docs/consumer.md
+++ b/internal/snell-rollcall/docs/consumer.md
@@ -1,0 +1,144 @@
+# RollCall consumer
+
+The outbound connector: `dhs consumer rollcall <verb> <host>`. It implements
+the neutral `consumer.Protocol` on top of the session layer, and adds the
+router command space, which nothing neutral has a shape for.
+
+---
+
+## Connecting
+
+One TCP connection to an IPShare gateway carries everything. The first message
+on it is a device enquiry addressed to the broadcast address, because a client
+knows neither its own address nor the gateway's until the gateway answers:
+
+```
+→ GETDEVINFO  0000-00-00:FF → 0000-00-00:FF
+← RETDEVINFO  0000-08-00:FF → 0000-01-E0:FF
+```
+
+The reply's **destination** is the address being assigned to us. The reply's
+**source** is the gateway. Both come from the frame header rather than from the
+payload, because the address inside a `DEVICEINFO_STR` is never rewritten as a
+message crosses a bridge and so means nothing about the route.
+
+## Sessions
+
+A session is a set of services at a user level, and the services are granted
+all-or-nothing: a call naming one the peer does not have is refused entirely.
+So the mask asked for is the intersection of what we want with what the peer
+advertised — measured against a controller that has no display service and
+refuses every call naming one.
+
+Sessions are per node and kept, because opening one costs a round trip and
+closing one is what a unit runs out of. There are three kinds:
+
+| Session | Services | Why separate |
+|---|---|---|
+| control | menus, control, display where offered, long strings where offered | the one everything ordinary uses |
+| file | file | a unit without a file service must still be controllable |
+| map | map | a request outside a session's services is answered `INVSESS` |
+
+Two indices matter and confusing them is the defect the session layer exists to
+prevent. Ours goes in the source of everything we send; the peer's goes in the
+destination. A push arrives addressed to ours.
+
+## Slots
+
+A slot is a position in the device's own enumeration, and its address is
+whatever the device put there — a port on a frame, a unit on a controller. The
+address appears in the slot's identity, because on a controller a slot number
+is a position in a list rather than a place in a frame.
+
+A slot past the end of the enumeration is still addressed rather than refused:
+a gateway ages a map entry out after sixty seconds of silence, so a node
+missing from the list is one that has gone quiet.
+
+## Walking a menu
+
+A menu is a flat array with nested spans: a container's step is the size of its
+whole subtree, not the count of its children. The walk turns that into a tree,
+and the tree is what makes `--label` and `--path` work without the caller
+knowing a command number.
+
+Both generations produce the same tree. A 16-bit client fetches a block header
+and then each line by offset; a long-string client asks for a count and then
+each line by absolute index. What arrives differs in width, not in meaning.
+
+Menus are cached per slot. A `FUNCLISTCHG` or `FUNCSTYLECHG` push drops the
+cache, because a line that became hidden or disabled is a line whose access we
+would otherwise report wrongly.
+
+## Values
+
+A read answers with the value; a write answers with the value that was
+**stored**. That is worth relying on: a device clamps silently, and only the
+reply says what it clamped to.
+
+| Kind | Wire form | Note |
+|---|---|---|
+| number | `ModeValue`, scaled by the line's divisor | a real is an integer over a factor; the format string is where the unit lives |
+| boolean | `ModeValue`, 0 or 1 | on a checkbox the *minimum* field is the "on" value, not a bound |
+| string | `ModeString` | 19 usable bytes in the older generation, 63 in the newer |
+| raw | `ModeData` | reported, never written |
+
+Both `ModeValue` and `ModeString` set at once is normal rather than
+exceptional: a device answers a checksum with the number -1686180113 *and* the
+string "0x9B7EEEEF", and a display wants the string.
+
+## Subscriptions
+
+Two messages open a value stream and the second is easy to miss: opening the
+back channel makes a session able to receive pushes, and asking for change
+reporting is what makes a device send value pushes at all. With only the first,
+a subscription looks live and nothing arrives.
+
+Every push is a request. The acknowledgement is what asks for the next, so it
+goes after the callback has run: sending it first throws away the only flow
+control the protocol has.
+
+## Files
+
+The file service is not an extra. A router publishes its names through it, and
+the vendor's Control Panel will not render a device without reading
+`TEMPLATE.ZIP` from it.
+
+Two fields change meaning between a request and its own reply, and getting it
+wrong reads a file as a stream of empty blocks rather than failing:
+
+| Message | `rOffset` | `rExtra` |
+|---|---|---|
+| `SP_FILEOPEN` | unused | the open flags |
+| `SP_RETFILEOPEN` | the peer's block size | the error |
+| `SP_FILEREAD` | where to read from | how many bytes |
+| `SP_RETFILEREAD` | how many were read | the error |
+
+Always open binary. Text mode makes a peer translate line endings, which
+corrupts an archive or a names file silently: the read succeeds and the bytes
+are wrong.
+
+## Routers
+
+A router has no menu. See [runbook.md](runbook.md) §6 for the operational view;
+the shape of the client is:
+
+```go
+r, _ := p.FindRouter(ctx)                     // probes command 100 on each node
+names, _ := p.LevelNames(ctx, r, 1, 1, 32)    // bulk file, checksum-verified
+p.WatchRoutes(ctx, r, func(x Crosspoint) {…}) // tally
+p.SetRoute(ctx, r, 1, 1, 4, src, 0)           // make a route
+p.Protect(ctx, r, 1, 1, 4)                    // who holds it
+p.FireSalvo(ctx, r, 2)
+```
+
+`FindRouter` probes because nothing in a device list says which node serves the
+interface. The test is strict: the interface version must be a number in a
+plausible range, because a card is not obliged to refuse command 100 — on a
+Centra the input cards answer it with their own model number as a string.
+
+## Compliance
+
+Every deviation is absorbed and counted rather than worked around. The list is
+in [runbook.md](runbook.md) §7. `ComplianceEvents()` returns them, one entry per
+kind with a count and the most recent detail: a device that misbehaves on every
+one of sixty-five thousand destinations must not fill memory with the evidence.

--- a/internal/snell-rollcall/docs/runbook.md
+++ b/internal/snell-rollcall/docs/runbook.md
@@ -1,0 +1,201 @@
+# RollCall — operational runbook
+
+What to run, in what order, and what the answers mean. For the wire format see
+[../CLAUDE.md](../CLAUDE.md); for measured device behaviour see
+[oracle-centra.md](oracle-centra.md).
+
+---
+
+## 1. Bring-up, in order
+
+Each step tells you something the next one needs. Stopping at the first failure
+is the point.
+
+```
+dhs consumer rollcall info <host>
+```
+
+| What you see | What it means |
+|---|---|
+| `slots N` and a status line per slot | The link, the handshake, the map service and the session service all work. Go on. |
+| `dial …: connection refused` | Nothing is listening. A frame listens on 2050; a Centra's IPShare port is configurable and is often **2057**. |
+| `handshake …: reply timeout` | Something accepted TCP and did not answer a device enquiry. Wrong port, or a device that is not RollCall. |
+| `call …: NACK` | The unit refused the session. Almost always a service it does not have — see §4. |
+| `port list …: INVSESS` | The map service was asked for on a session that did not negotiate it. A bug on our side; report it. |
+
+Then walk one node:
+
+```
+dhs consumer rollcall walk <host> --slot 1
+```
+
+A frame's cards answer with tens to hundreds of objects. A router node answers
+with two or three, and that is correct: routing is not in the menu.
+
+## 2. Slots
+
+A slot number is a position in the device's own enumeration, and the address
+behind it comes from the device. Two shapes exist and the difference matters:
+
+- **A frame** enumerates the ports of one unit. Slot 0 is the first card.
+- **A controller** enumerates units: the matrices, the tielines engine, the
+  panel driver that serves routing, and every card in the frames it fronts.
+  Slot 9 might be `0000-81-00`, the XY Panel.
+
+`info` prints each slot's identity, and the address is in the JSON:
+
+```
+dhs consumer rollcall info <host> --output json | jq '.slot_status[] | {slot, identity}'
+```
+
+## 3. Verbs
+
+### Consumer
+
+| Verb | What it does | Notes |
+|---|---|---|
+| `info <host>` | identity, slot count, per-slot status | costs one enumeration |
+| `walk <host> --slot N` | every object on a node | caches the menu for label lookups |
+| `get <host> --slot N --label X` | read one object | `--id` takes the command number instead |
+| `set <host> --slot N --label X --value V` | write one object | answers with the **stored** value |
+| `reset <host> --slot N --label X` | ask the device for its own default | the numeric field is ignored |
+| `watch <host> --slot N` | subscribe to value changes | opens the back channel |
+| `router <host>` | find and print a routing interface | probes every node unless `--slot` |
+| `route <host> --matrix M --level L --dest D [--source S]` | read or make a crosspoint | waits for the tally |
+| `tally <host> --matrix M --level L [--names]` | print a level, then follow it | Ctrl+C to stop |
+
+### Producer
+
+```
+dhs producer rollcall serve --tree tree.json --port 2050
+```
+
+Serves a canonical tree as a gateway: the root is the frame, each child is a
+card slot. See [provider.md](provider.md).
+
+## 4. When a session is refused
+
+`SP_NACK` to a call is the commonest failure and it has three usual causes.
+
+**A service the peer does not have.** Services are all-or-nothing: naming one
+the unit lacks refuses the whole call. Our consumer intersects what it wants
+with what the peer advertised, so this should not happen — but if a unit
+advertises a service and then refuses it, that is a compliance event
+(`rollcall_long_strings_refused` is the one we have seen) and the fallback is
+automatic.
+
+**The unit is out of sessions.** Servers do not time idle sessions out. The
+vendor's own comments say units "don't time them out very well (at all), and
+then run out of available sessions". A unit that has been talked to by a
+crashed client stays that way until it reboots. The specification has
+`SP_BUSY` for this; the Centra sends `SP_NACK` instead, so a refusal is worth
+retrying before it is believed.
+
+**A user level the unit does not accept.** Four exist: engineer, operator,
+supervisor, factory. We ask for supervisor.
+
+## 5. Reading a capture
+
+The dissector is at
+[`wireshark/dhs_snell_rollcall.lua`](../wireshark/dhs_snell_rollcall.lua).
+Install it per [docs/wireshark.md](../../../docs/wireshark.md), then:
+
+| Question | Filter |
+|---|---|
+| All RollCall traffic | `dhs_snell_rollcall` |
+| Who opened what | `dhs_snell_rollcall.type == 2` |
+| One node only | `dhs_snell_rollcall.dst.unit == 0x81` |
+| Crosspoints | `dhs_snell_rollcall.source_pin` |
+| Tally, not replies | `dhs_snell_rollcall.flags.back_channel == 1` |
+| Refusals | `dhs_snell_rollcall.type in {0 14 15 23}` |
+
+A refusal type says which kind: `NACK` is "I understood and will not",
+`INVCMD` is "I do not know this message", `INVSESS` is "not on this session",
+`BUSY` is "try again".
+
+## 6. Routers
+
+Find the interface first. It is on one node and nothing in a device list says
+which:
+
+```
+dhs consumer rollcall router <host>
+```
+
+If that reports nothing, the device has no routing interface — a frame of cards
+does not. If it reports one, everything else follows from the matrices and
+levels it printed.
+
+**Three behaviours that surprise people**, all measured:
+
+1. **The reply to a route carries the previous crosspoint.** The result code
+   says whether it worked; the new value arrives afterwards on the back
+   channel. The `route` verb waits for it, so what it prints is what happened.
+
+2. **The tally follows tielines.** Ask for source 7 and read back matrix 2
+   source 1: the number reported is the *final upstream* source. The router is
+   working. Reading back what you wrote is not a valid expectation.
+
+3. **Subscribing does not fill in the picture.** Enabling the back channel does
+   not replay current state on a real controller, whatever the specification
+   says. Read the level once, then follow it. `tally` does both.
+
+Names come in bulk from files, verified by a checksum computed from the names
+themselves. Where a controller names a file its own file service will not serve
+— which the Centra does, because the path is in the controller's filesystem and
+each node's file service is rooted at its own directory — the names are read one
+command at a time and `rollcall_names_file_unreadable` is recorded. On a large
+level that is slow, and the event is there to explain why.
+
+## 7. Compliance events
+
+The connector absorbs a deviation and keeps working, then counts it. One entry
+per kind with the most recent detail, never one per occurrence.
+
+| Event | What it means |
+|---|---|
+| `rollcall_long_strings_refused` | A unit advertised the 32-bit generation and refused a call asking for it. We fell back. |
+| `rollcall_menu_span_overruns` | A container claimed a subtree longer than the menu holding it. Clamped. |
+| `rollcall_menu_count_mismatch` | A device announced one number of menu lines and sent another. |
+| `rollcall_duplicate_command` | Two menu lines claimed the same command number. |
+| `rollcall_access_gated` | A line was replaced by the placeholder a server substitutes above a user level. Not a fault. |
+| `rollcall_value_mode_empty` | A value reply set no flag, so it carried nothing. |
+| `rollcall_unsolicited_command` | A push named a command the walked menu does not list. Delivered anyway. |
+| `rollcall_display_line_out_of_range` | A status line outside the four and the two priorities. |
+| `rollcall_unlisted_node` | A slot was addressed that the enumeration did not mention. Addressed anyway. |
+| `rollcall_names_checksum_mismatch` | A names file did not hash to its published checksum. Names kept. |
+| `rollcall_names_file_unreadable` | A router named a names file it will not serve. Fell back to one command per name. |
+
+The provider has its own set, in [provider.md](provider.md).
+
+## 8. Integration runs
+
+```
+# loopback only
+ansible-playbook -i inventory/hosts.ini playbooks/snell-rollcall-integration.yml
+
+# with the vendor Centra emulator
+ROLLCALL_SIM_HOST=127.0.0.1 ROLLCALL_SIM_PORT=2057 ansible-playbook ...
+
+# with a live device, read-only
+ROLLCALL_TEST_HOST=10.6.250.105 ansible-playbook ...
+```
+
+The emulator lives in [`assets/Emulator/RouterSimulator`](../assets/Emulator/RouterSimulator).
+Unpack it somewhere writable and run `CentraController.exe`; set
+`CENTRA_SIMULATED_ROUTER=3` to make it a Sirius 800. It writes
+`FCSendRetValue: WARNING - command not valid` to stdout for every routing
+command it refuses, which is a quick way to tell a Full Control refusal from a
+session-layer one.
+
+## 9. Known device quirks
+
+| Device | What it does | What we do |
+|---|---|---|
+| Centra | No display service; refuses any call naming it | Ask only for what a peer advertises |
+| Centra | Nodes differ by unit, not port | Address by the enumeration's own address |
+| Centra | Cards answer command 100 with their model number as a string | Require a numeric interface version |
+| Centra | Directory entries are variable-length, not the declared 13-byte field | Read the name as what follows the header |
+| Centra | Names files named in its own filesystem, unreachable over RollCall | Fall back to one command per name |
+| Centra | Enabling the back channel replays nothing | Read the state, then follow it |
+| Any unit | Sessions are not timed out | Always send `SP_TERM`; a leaked session is held until reboot |


### PR DESCRIPTION
Stacked on #1033. ADR-0022 asks for one device model per **card type** rather
than per slot, so a frame of twelve identical cards is walked once. RollCall
has exactly the data for that and none of it was wired up.

## What the consumer can now say about itself

`Canonicalize` / `ExportCanonical` turn a walked menu into a canonical tree with
the nesting the device published — a container is a line whose *step* spans a
subtree — and each line becomes the parameter it is:

| Menu line | Canonical |
|---|---|
| number with a divisor | `real` **with its factor**, so the wire value stays recoverable |
| number without | `integer`, range and step as given |
| checkbox | `boolean` |
| editable string | `string`, range is a length |
| display / list / disabled | read-only |

The round trip holds. The committed frame tree, served by our provider, walked
by our consumer and re-exported:

```
127.0.0.1 [node] read
  slot-0 [node] read
    card1 [node] read
      identity [node] read
        product [string] read
      video [node] read
        gain [real] readWrite  min=-60 max=6 factor=10 fmt='%0.2f dB'
        enable [boolean] readWrite
      status [integer] read  min=0 max=9
```

Same shape, same factor, same access as the tree that went in.

## IdentityProbe keys on the model, not the label

A card's name is user-editable — one is `CAM 1 PROC`, the identical card beside
it is `SPARE`. What identifies a model is the vendor's type id and the
firmware's command set, which is what the specification itself says. So the
identity is `<type>@<major>.<minor>.cs<n>`, sanitised for a path (the vendor's
own names include `4929 AES O/P card`). It costs **one message** — a walk there
would be minutes on a large card, and it runs before anything else wants the
link.

## Two defects in shared CLI code, found by using it

- **`writeCanonicalCapture` dispatched on concrete plugin type** and silently
  wrote nothing for anything not in its list of three. `probel-sw08p` has had a
  `Canonicalize` the CLI has never called. It now asks for the *method*.
- **`extract` renamed the capture file while the recorder still held it open**,
  which fails on Windows: no `tree.json`, and a warning nobody would connect to
  the cause. The recorder is closed before the rename.

`dhs consumer rollcall extract` now produces the full `{meta.json, wire.jsonl,
tree.json}` triple with a fingerprint. Verified for both a card with a nested
menu and one with a flat one; acp1 and the CLI suite unaffected.

Coverage stays at 100% in the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)