### PR TITLE
fix(cli): carry the per-slot identity into info --output json

### DIFF
--- a/cmd/dhs/cmd_info.go
+++ b/cmd/dhs/cmd_info.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
+	"dhs/internal/consumer"
 )
 
 func runInfo(ctx context.Context, args []string) error {
@@ -35,22 +37,7 @@ func runInfo(ctx context.Context, args []string) error {
 		return err
 	}
 	if jsonOut {
-		out := deviceInfoJSON{
-			Device: fmt.Sprintf("%s:%d", info.IP, info.Port), Protocol: cf.protocol,
-			ProtocolVersion: info.ProtocolVersion, DtdVersion: info.DtdVersion,
-			Slots: info.NumSlots,
-		}
-		for slot := 0; slot < info.NumSlots; slot++ {
-			si, serr := plug.GetSlotInfo(opCtx, slot)
-			s := slotInfoJSON{Slot: slot}
-			if serr != nil {
-				s.Error = serr.Error()
-			} else {
-				s.Status, s.Online = si.Status.String(), si.IsOnline
-			}
-			out.SlotStatus = append(out.SlotStatus, s)
-		}
-		return emitReadJSON(out)
+		return emitReadJSON(buildInfoJSON(opCtx, plug, info, cf.protocol))
 	}
 	fmt.Printf("device       %s:%d\n", info.IP, info.Port)
 	fmt.Printf("protocol     %s v%d\n", cf.protocol, info.ProtocolVersion)
@@ -78,6 +65,28 @@ func runInfo(ctx context.Context, args []string) error {
 	return nil
 }
 
+// buildInfoJSON assembles the machine shape of `info` by asking the plugin
+// about every slot. A slot that cannot be read carries its error rather than
+// disappearing: a frame with one unreadable card still describes the rest.
+func buildInfoJSON(ctx context.Context, plug consumer.Protocol, info consumer.DeviceInfo, protocol string) deviceInfoJSON {
+	out := deviceInfoJSON{
+		Device: fmt.Sprintf("%s:%d", info.IP, info.Port), Protocol: protocol,
+		ProtocolVersion: info.ProtocolVersion, DtdVersion: info.DtdVersion,
+		Slots: info.NumSlots,
+	}
+	for slot := 0; slot < info.NumSlots; slot++ {
+		si, err := plug.GetSlotInfo(ctx, slot)
+		s := slotInfoJSON{Slot: slot}
+		if err != nil {
+			s.Error = err.Error()
+		} else {
+			s.Status, s.Online, s.Identity = si.Status.String(), si.IsOnline, si.Identity
+		}
+		out.SlotStatus = append(out.SlotStatus, s)
+	}
+	return out
+}
+
 // deviceInfoJSON / slotInfoJSON are the machine shape of `info`
 // (#751 G1c). Per-slot errors are carried, never swallowed.
 type deviceInfoJSON struct {
@@ -94,4 +103,12 @@ type slotInfoJSON struct {
 	Status string `json:"status,omitempty"`
 	Online bool   `json:"online"`
 	Error  string `json:"error,omitempty"`
+
+	// Identity is whatever the plugin knows about what is in the slot. On a
+	// frame a slot number names a place and the identity is a convenience; on
+	// a controller a slot number is a position in a list and the identity —
+	// the node's address above all — is the only thing that names the node.
+	// Omitted when the plugin fills nothing in, so protocols without the
+	// notion keep the shape they had.
+	Identity map[string]string `json:"identity,omitempty"`
 }

--- a/cmd/dhs/cmd_info_json_test.go
+++ b/cmd/dhs/cmd_info_json_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"dhs/internal/consumer"
+)
+
+// slotSource answers GetSlotInfo from a canned table, so a test can describe a
+// frame without one existing.
+type slotSource struct {
+	fakePlugin
+	slots map[int]consumer.SlotInfo
+	errs  map[int]error
+}
+
+func (s *slotSource) GetSlotInfo(ctx context.Context, slot int) (consumer.SlotInfo, error) {
+	if err := s.errs[slot]; err != nil {
+		return consumer.SlotInfo{}, err
+	}
+	return s.slots[slot], nil
+}
+
+func TestInfoJSONCarriesTheIdentityAPluginFilledIn(t *testing.T) {
+	// On a controller a slot number is a position in a list rather than a place
+	// in a frame, and the address behind it is the only thing that names the
+	// node. The runbook tells operators to read it out of this JSON.
+	src := &slotSource{
+		slots: map[int]consumer.SlotInfo{
+			0: {Slot: 0, Status: consumer.SlotPresent, IsOnline: true,
+				Identity: map[string]string{"type": "Vega Controller", "address": "0000-81-00:007"}},
+			1: {Slot: 1, Status: consumer.SlotPresent, IsOnline: true},
+		},
+	}
+
+	out := buildInfoJSON(context.Background(), src,
+		consumer.DeviceInfo{IP: "10.6.250.105", Port: 2050, NumSlots: 2, ProtocolVersion: 3}, "rollcall")
+
+	if len(out.SlotStatus) != 2 {
+		t.Fatalf("%d slots described, want 2", len(out.SlotStatus))
+	}
+	if got := out.SlotStatus[0].Identity["address"]; got != "0000-81-00:007" {
+		t.Errorf("slot 0 address = %q; the identity is what names a node", got)
+	}
+	if got := out.SlotStatus[0].Identity["type"]; got != "Vega Controller" {
+		t.Errorf("slot 0 type = %q", got)
+	}
+
+	// A plugin that fills nothing in leaves the key out entirely, so every
+	// protocol without the notion keeps the shape it had.
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		SlotStatus []map[string]any `json:"slot_status"`
+	}
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := decoded.SlotStatus[1]["identity"]; ok {
+		t.Error("a slot with no identity should carry no identity key")
+	}
+	if _, ok := decoded.SlotStatus[0]["identity"]; !ok {
+		t.Error("a slot with an identity should carry one")
+	}
+}
+
+func TestInfoJSONKeepsASlotThatWouldNotAnswer(t *testing.T) {
+	// A frame with one unreadable card still describes the rest, and the one
+	// that failed says why rather than disappearing.
+	src := &slotSource{
+		slots: map[int]consumer.SlotInfo{0: {Slot: 0, Status: consumer.SlotPresent, IsOnline: true}},
+		errs:  map[int]error{1: errors.New("reply timeout")},
+	}
+
+	out := buildInfoJSON(context.Background(), src,
+		consumer.DeviceInfo{IP: "h", Port: 1, NumSlots: 2}, "rollcall")
+
+	if len(out.SlotStatus) != 2 {
+		t.Fatalf("%d slots described, want both", len(out.SlotStatus))
+	}
+	if !strings.Contains(out.SlotStatus[1].Error, "reply timeout") {
+		t.Errorf("slot 1 error = %q", out.SlotStatus[1].Error)
+	}
+	if out.SlotStatus[1].Status != "" || out.SlotStatus[1].Identity != nil {
+		t.Error("a slot that did not answer describes nothing but its error")
+	}
+	if out.Device != "h:1" || out.Protocol != "rollcall" {
+		t.Errorf("device = %q protocol = %q", out.Device, out.Protocol)
+	}
+}


### PR DESCRIPTION
Closes #1035.

`info --output json` described a slot by number, status and online flag and stopped there, so the `Identity` map a plugin fills in after enumeration never reached the caller. The RollCall runbook already documented reading it:

```
dhs consumer rollcall info <host> --output json | jq '.slot_status[] | {slot, identity}'
```

which returned `null` for every slot.

## Why it matters

On a frame a slot number names a place and the identity is a convenience. On a controller a slot number is a position in a list, and the node's address is the only thing that names it.

Measured against the vendor Centra emulator, two clean instances of the same build on separate ports:

| | `CENTRA_SIMULATED_ROUTER=2` | `CENTRA_SIMULATED_ROUTER=4` |
|---|---|---|
| gateway type | `Nucleus 2` | `Vega Controller` |
| nodes | 15 | 6 |
| routing interface | slot 14 (`0000-81-00:010`) | slot 5 (`0000-81-00:007`) |

The JSON could not tell those two devices apart.

## Shape

`identity` is `omitempty`, so a protocol with no notion of a slot identity emits exactly what it did before.

## Refactor

The JSON assembly moves out of `runInfo` into `buildInfoJSON` so it can be tested without a device. Behaviour is unchanged, including a slot that fails to answer carrying its error rather than disappearing from the list.

## Tests

`buildInfoJSON` at 100% statement coverage: identity carried through and absent-key-when-empty; a slot that would not answer keeps its error and describes nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)