### PR TITLE
fix(snell-rollcall): name a slot by its node address

### DIFF
--- a/internal/snell-rollcall/consumer/consumer_test.go
+++ b/internal/snell-rollcall/consumer/consumer_test.go
@@ -470,6 +470,35 @@ func TestGetSlotInfo(t *testing.T) {
 	if info.Identity["category"] == "" {
 		t.Error("the product category should be reported")
 	}
+
+	// The address is the node itself. A slot number is a position in the
+	// device's own enumeration rather than a place in a frame, so on a
+	// controller it names nothing on its own — the routing interface sits on
+	// slot 14 of one model and slot 5 of another — and only the address says
+	// which node answered.
+	if got := info.Identity["address"]; got != "0000-08-01:0FF" {
+		t.Errorf("address = %q, want the address the enumeration gave slot 1", got)
+	}
+}
+
+// TestGetSlotInfoAddressesEachNodeSeparately covers the reason the address is
+// reported at all: two slots are two nodes, and the identity has to say which.
+func TestGetSlotInfoAddressesEachNodeSeparately(t *testing.T) {
+	h := newHarness(t, nil)
+	ctx := context.Background()
+
+	one, err := h.plugin.GetSlotInfo(ctx, 1)
+	if err != nil {
+		t.Fatalf("GetSlotInfo(1): %v", err)
+	}
+	two, err := h.plugin.GetSlotInfo(ctx, 2)
+	if err != nil {
+		t.Fatalf("GetSlotInfo(2): %v", err)
+	}
+	if one.Identity["address"] == two.Identity["address"] {
+		t.Errorf("both slots report %q; an address that does not distinguish nodes reports nothing",
+			one.Identity["address"])
+	}
 }
 
 // TestGetSlotInfo_EmptySlot covers a port with nothing fitted, which a unit

--- a/internal/snell-rollcall/consumer/discover.go
+++ b/internal/snell-rollcall/consumer/discover.go
@@ -165,6 +165,17 @@ func (p *Plugin) GetSlotInfo(ctx context.Context, slot int) (consumer.SlotInfo, 
 		IsOnline: st.Status.Has(codec.StatusPresent),
 		LiveAt:   p.clk.Now(),
 		Identity: map[string]string{
+			// The address is the node itself. A slot number is a position in
+			// the device's own enumeration rather than a place in a frame, so
+			// on a controller it names nothing on its own: the routing
+			// interface is slot 14 on one model and slot 5 on another, and
+			// only the address says which node was reached. It costs nothing
+			// to report — the session already knows who it is talking to.
+			// The session index is dropped: it is an artefact of this
+			// conversation rather than of the node, it differs on every
+			// reconnection, and leaving it in would make two walks of one card
+			// look like two device models.
+			"address":  s.Peer().Device().String(),
 			"name":     id.Name,
 			"type":     codec.UnitTypeName(id.TypeID),
 			"type_id":  fmt.Sprint(id.TypeID),


### PR DESCRIPTION
Closes #1037. Stacked on #1034.

A slot's identity carried `name`, `type`, `type_id`, `version`, `services`, `product` and `category` — and not the one field `docs/runbook.md` §2 told operators to read.

On a controller a slot number is a position in the device's own enumeration rather than a place in a frame, so it names nothing on its own.

## Measured

Two clean copies of the vendor Centra emulator, same build, on separate ports, differing only by `CENTRA_SIMULATED_ROUTER`:

```
======== id 2 (Pyxis) ========          ======== id 4 (Vega) ========
slot address          type               slot address          type
0    0000-08-00:0FF   Nucleus 2          0    0000-08-00:0FF   Vega Controller
1    0000-11-00:0FF   Router Matrix      1    0000-0A-00:0FF   Vega 2RU
2    0000-12-00:0FF   Router Matrix      2    0000-11-00:0FF   Router Matrix
3..12 0000-41..66     12 iCards          3    0000-12-00:0FF   Router Matrix
13   0000-80-00:0FF   TIELINES           4    0000-80-00:0FF   TIELINES
14   0000-81-00:0FF   XY Panel           5    0000-81-00:0FF   XY Panel
```

The XY Panel is `0000-81-00` on both. Its **slot number** is 14 on one and 5 on the other. A script that keys on the slot breaks between models; one that keys on the address does not. Before this change the JSON offered only the slot.

## No extra cost

The address comes from the session's peer, which is already known — no round trip.

## The session index is dropped

`Peer()` carries the peer's session index (`0000-08-01:031`). That is an artefact of one conversation rather than of the node: it differs on every reconnection, and leaving it in would make two walks of one card look like two device models. Reported as `Peer().Device()`.

## Tests

Package stays at 100% statement coverage. `TestGetSlotInfo` pins the exact address; `TestGetSlotInfoAddressesEachNodeSeparately` pins that two slots do not report one address, which is the whole point of the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)