### PR TITLE
fix(snell-rollcall): a router address names the node, not the session

### DIFF
--- a/internal/snell-rollcall/consumer/router.go
+++ b/internal/snell-rollcall/consumer/router.go
@@ -34,6 +34,11 @@ import (
 // RouterInterface is what a router node publishes about itself.
 type RouterInterface struct {
 	// Slot is the node this was read from, and Addr the address behind it.
+	//
+	// Addr carries no session index. The index is an artefact of one
+	// conversation rather than of the node — the same panel reported itself as
+	// :010 on one run and :026 on the next — so leaving it in makes two runs
+	// against an unchanged router differ for no reason.
 	Slot int
 	Addr codec.Address
 
@@ -143,7 +148,7 @@ func (p *Plugin) RouterAt(ctx context.Context, slot int) (*RouterInterface, erro
 			"rollcall: slot %d speaks the 16-bit generation, which has no routing interface", slot)
 	}
 
-	r := &RouterInterface{Slot: slot, Addr: s.Peer()}
+	r := &RouterInterface{Slot: slot, Addr: s.Peer().Device()}
 
 	// The interface version is the whole of the test for "is this a router",
 	// so it has to be a strict one. A card is not obliged to refuse command

--- a/internal/snell-rollcall/consumer/router_test.go
+++ b/internal/snell-rollcall/consumer/router_test.go
@@ -124,6 +124,17 @@ func TestFindRouterProbesEveryNode(t *testing.T) {
 	if r.Slot != 2 {
 		t.Errorf("found the router on slot %d, want 2", r.Slot)
 	}
+
+	// The address names the node and nothing else. A session index would make
+	// two runs against an unchanged router differ — the same panel reported
+	// itself as :010 on one run and :026 on the next — so the printed address
+	// carries none.
+	if r.Addr.Index != codec.IndexUnknown {
+		t.Errorf("addr = %s; a router address carries no session index", r.Addr)
+	}
+	if r.Addr.Unit == 0 && r.Addr.Port == 0 {
+		t.Errorf("addr = %s names no node", r.Addr)
+	}
 }
 
 func TestFindRouterOnADeviceWithNone(t *testing.T) {


### PR DESCRIPTION
Stacked on #1040.

`dhs consumer rollcall router` printed the address with the peer's session index on it:

```
slot         14 (0000-81-00:010)     <- one run
slot         14 (0000-81-00:026)     <- the next run, same unchanged panel
```

The index is an artefact of one conversation rather than of the node. Two runs against a router nobody touched differ, which makes the output useless to diff and misleading to script against.

Dropped, the same way a slot's identity drops it (#1037).

## Tests

`TestFindRouterProbesEveryNode` now pins that the address carries no session index and still names a node. Package stays at 100% statement coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)